### PR TITLE
Getting wdns to build on mac by removing unknown ld options in AM_LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 	-include $(top_builddir)/config.h \
 	-I$(top_srcdir)/wdns
 AM_CFLAGS = $(my_CFLAGS)
-AM_LDFLAGS = -Wl,--as-needed
 
 EXTRA_DIST += COPYRIGHT
 


### PR DESCRIPTION
I'm not sure if you want this pull request, but I figured I'd put it out there.  I'm not exactly certain what the exact consequences are of removing the unknown AM_LDFLAGS for ld on mac.
