### PR TITLE
examples/wdns-dump-file: New

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,12 @@ pkgconfig_DATA = wdns/libwdns.pc
 EXTRA_DIST += wdns/libwdns.pc.in
 CLEANFILES += wdns/libwdns.pc
 
+bin_PROGRAMS += examples/wdns-dump-file
+examples_wdns_dump_file_LDADD = wdns/libwdns.la
+examples_wdns_dump_file_SOURCES = \
+	examples/private.h \
+	examples/wdns-dump-file.c
+
 if LIBPCAP
 bin_PROGRAMS += examples/wdns-dump-pcap
 examples_wdns_dump_pcap_LDADD = wdns/libwdns.la -lpcap

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
+wdns-dump-file
 wdns-dump-pcap
 wdns-test-deserialize-rrset
 wdns-test-downcase-rrset

--- a/examples/wdns-dump-file.c
+++ b/examples/wdns-dump-file.c
@@ -1,0 +1,61 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "private.h"
+
+#include <wdns.h>
+
+static int
+process_data(const uint8_t *data, size_t len)
+{
+	wdns_message_t m;
+	wdns_res res;
+
+	res = wdns_parse_message(&m, data, len);
+	if (res == wdns_res_success) {
+		wdns_print_message(stdout, &m);
+		wdns_clear_message(&m);
+		putchar('\n');
+		return EXIT_SUCCESS;
+	} else {
+		return EXIT_FAILURE;
+	}
+}
+
+int
+main(int argc, char **argv) {
+	FILE *fp;
+
+	uint8_t data[4096] = {0};
+	size_t len;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s <INFILE>\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	fp = fopen(argv[1], "r");
+	if (fp == NULL) {
+		fprintf(stderr, "Error: unable to open %s: %s\n", argv[1], strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	len = fread(data, 1, sizeof(data), fp);
+	if (ferror(fp)) {
+		fprintf(stderr, "Error: fread() returned an error on %s\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	if (!feof(fp)) {
+		fprintf(stderr, "Error: did not make a complete read of %s\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+
+	return process_data(data, len);
+}


### PR DESCRIPTION
This is a driver for wdns_parse_message() + wdns_print_message() that
reads a raw DNS message from a file, with no framing. This is useful for
fuzzing wdns with e.g. afl.