### PR TITLE
parse_rdata: Treat rdf_uname the same as rdf_name

### DIFF
--- a/wdns/parse_rdata.c
+++ b/wdns/parse_rdata.c
@@ -64,6 +64,7 @@ _wdns_parse_rdata(wdns_rr_t *rr, const uint8_t *p, const uint8_t *eop,
 
 			switch (*t) {
 			case rdf_name:
+			case rdf_uname:
 				res = wdns_unpack_name(p, eop, src, domain_name, &len);
 				if (res != wdns_res_success)
 					goto parse_error;
@@ -72,14 +73,6 @@ _wdns_parse_rdata(wdns_rr_t *rr, const uint8_t *p, const uint8_t *eop,
 					res = wdns_res_out_of_bounds;
 					goto parse_error;
 				}
-				ubuf_append(u, domain_name, len);
-				break;
-
-			case rdf_uname:
-				res = wdns_copy_uname(p, eop, src, domain_name, &len);
-				if (res != wdns_res_success)
-					goto parse_error;
-				advance_bytes(len);
 				ubuf_append(u, domain_name, len);
 				break;
 


### PR DESCRIPTION
This commit treats rdf_name's and rdf_name's exactly the same when
decompressing domain names embedded in rdata. This affects the parsing
of DNAME, A6, KX, RRSIG, and NSEC RR's, which are currently defined in
record_descr with rdf_uname's. The use of rdf_uname in the record_descr
definitions indicates that those RRs are specified as being generated
without compression pointers.

However, the DNS specifications only require that *generators* of these
RR's must not use compression pointers. Consumers are not required to
enforce this restriction, which allows bad generator code to persist.

This change should result in more lenient parsing of RRSIG and NSEC
records in particular, as some commonly deployed proprietary DNSSEC
implementations incorrectly generate these records with compression
pointers.