### PR TITLE
t/: Fix format specifiers for size_t

### DIFF
--- a/t/test-rdata_to_str.c
+++ b/t/test-rdata_to_str.c
@@ -262,7 +262,7 @@ check(size_t ret, const char *s)
         if (ret == 0)
                 fprintf(stderr, NAME ": PASS: %s\n", s);
         else
-                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
+                fprintf(stderr, NAME ": FAIL: %s (%zd failures)\n", s, ret);
         return (ret);
 }
 

--- a/t/test-str_to_name.c
+++ b/t/test-str_to_name.c
@@ -129,7 +129,7 @@ check(size_t ret, const char *s)
 	if (ret == 0)
 		fprintf(stderr, NAME ": PASS: %s\n", s);
 	else
-		fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
+		fprintf(stderr, NAME ": FAIL: %s (%zd failures)\n", s, ret);
 	return (ret);
 }
 

--- a/t/test-str_to_rcode.c
+++ b/t/test-str_to_rcode.c
@@ -58,7 +58,7 @@ check(size_t ret, const char *s)
 	if (ret == 0)
 		fprintf(stderr, NAME ": PASS: %s\n", s);
 	else
-		fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
+		fprintf(stderr, NAME ": FAIL: %s (%zd failures)\n", s, ret);
 	return (ret);
 }
 

--- a/t/test-str_to_rdata.c
+++ b/t/test-str_to_rdata.c
@@ -361,7 +361,7 @@ check(size_t ret, const char *s)
         if (ret == 0)
                 fprintf(stderr, NAME ": PASS: %s\n", s);
         else
-                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
+                fprintf(stderr, NAME ": FAIL: %s (%zd failures)\n", s, ret);
         return (ret);
 }
 

--- a/t/test-str_to_rrtype.c
+++ b/t/test-str_to_rrtype.c
@@ -124,7 +124,7 @@ check(size_t ret, const char *s)
         if (ret == 0)
                 fprintf(stderr, NAME ": PASS: %s\n", s);
         else
-                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
+                fprintf(stderr, NAME ": FAIL: %s (%zd failures)\n", s, ret);
         return (ret);
 }
 


### PR DESCRIPTION
Use `"%zd"` to format size_t, not `"%" PRIu64`. Otherwise clang generates the following diagnostics:

```
  CC       t/test-str_to_name.o
../t/test-str_to_name.c:132:66: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
                                                  ~~~                          ^~~
1 warning generated.
  CCLD     t/test-str_to_name
  CC       t/test-str_to_rcode.o
../t/test-str_to_rcode.c:61:66: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
                                                  ~~~                          ^~~
1 warning generated.
  CCLD     t/test-str_to_rcode
  CC       t/test-str_to_rdata.o
../t/test-str_to_rdata.c:364:80: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
                                                  ~~~                          ^~~
1 warning generated.
  CCLD     t/test-str_to_rdata
  CC       t/test-rdata_to_str.o
../t/test-rdata_to_str.c:265:80: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
                                                  ~~~                          ^~~
1 warning generated.
  CCLD     t/test-rdata_to_str
  CC       t/test-str_to_rrtype.o
../t/test-str_to_rrtype.c:127:80: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                fprintf(stderr, NAME ": FAIL: %s (%" PRIu64 " failures)\n", s, ret);
                                                  ~~~                          ^~~
1 warning generated.
```