### PR TITLE
Preserve character-string boundaries when formatting TXT rdata.

### DIFF
--- a/t/test-rdata_to_str.c
+++ b/t/test-rdata_to_str.c
@@ -45,7 +45,7 @@ struct test tdata[] = {
 		.input_len = 1 + 4 + 1 + 4,
 		.rrtype = WDNS_TYPE_TXT,
 		.rrclass = WDNS_CLASS_IN,
-		.expected = "\"sometext\"",
+		.expected = "\"some\" \"text\"",
 	},
 
 	{

--- a/wdns/rdata_to_ubuf.c
+++ b/wdns/rdata_to_ubuf.c
@@ -273,17 +273,15 @@ _wdns_rdata_to_ubuf(ubuf *u, const uint8_t *rdata, uint16_t rdlen,
 		}
 
 		case rdf_repstring:
-			ubuf_add_cstr(u, "\"");
 			while (src_bytes > 0) {
 				bytes_required(1);
 				oclen = *src;
 				bytes_consumed(1);
 
 				bytes_required(oclen);
-				len = rdata_to_str_string_unquoted(src, oclen, u);
+				len = rdata_to_str_string(src, oclen, u);
 				bytes_consumed(len);
 			}
-			ubuf_add_cstr(u, "\" ");
 			break;
 
 		case rdf_rrtype: {


### PR DESCRIPTION
This partially reverts 884f17701bbde47a86b8f05e29ca6c9795617ad7.