### PR TITLE
Handle corner case of NSEC3 hash field with length zero.

### DIFF
--- a/wdns/rdata_to_ubuf.c
+++ b/wdns/rdata_to_ubuf.c
@@ -179,6 +179,20 @@ _wdns_rdata_to_ubuf(ubuf *u, const uint8_t *rdata, uint16_t rdlen,
 			bytes_required(1);
 			oclen = *src++;
 			bytes_required(1 + oclen);
+			/*
+			 * RFC 5155 provides a "-" notation for salt with length zero,
+			 * but no similar notation for hash with length zero. We use a
+			 * single "0" character in this case to preserve the presentation
+			 * syntax requirement of a sequence of base32 digits, while not
+			 * conflicting with the base32 encoding of any one (or more) byte
+			 * sequences.
+			 */
+			if (oclen == 0) {
+				ubuf_add_cstr(u, "0 ");
+				src_bytes --;
+				break;
+			}
+
 			buf = alloca(2 * oclen + 1);
 			len = base32_encode(buf, 2 * oclen + 1, src, oclen);
 			ubuf_append(u, (uint8_t *) buf, len);

--- a/wdns/str_to_rdata_ubuf.c
+++ b/wdns/str_to_rdata_ubuf.c
@@ -353,6 +353,19 @@ _wdns_str_to_rdata_ubuf(ubuf *u, const char *str,
 			}
 
 			size_t str_len = end-str;
+
+			/*
+			 * The hashed owner name is presented as one base32 digit.
+			 * A single byte would be two base32 digits, therefore we
+			 * we can conclude the original data was zero bytes long.
+			 */
+			if (str_len == 1) {
+				uint8_t c = 0;
+				ubuf_append(u, &c, 1);
+				str++;
+				break;
+			}
+
 			buf = malloc(str_len);
 			buf_len = base32_decode(buf, str_len, str, str_len);
 


### PR DESCRIPTION
Fix printing and parsing of odd NSEC3 records with zero-length hashes.

RFC 5155's presentation format does not have an explicit notation for such hashes (e.g. "-" as used for zero-length salt), so we use a single "0". This preserves the presentation format requirement of a sequence of unpadded base32 digits, while not being a valid base32 encoding of any nonempty byte string.