### PR TITLE
Add code-coverage instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.la
 *.lo
 *.o
+*.gcno
 *.tar.gz
 .deps/
 .dirstamp
@@ -28,3 +29,6 @@ t/test-str_to_rrtype
 t/test-rdata_to_str
 t/*.log
 t/*.trs
+t/*.gcda
+coveragereport/
+coverage.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -188,3 +188,7 @@ TESTS += t/test-str_to_rrtype
 check_PROGRAMS += t/test-str_to_rrtype
 t_test_str_to_rrtype_SOURCES = t/test-str_to_rrtype.c
 t_test_str_to_rrtype_LDADD = wdns/libwdns.la
+
+
+# coverage
+include $(top_srcdir)/Makefile.am.coverage

--- a/Makefile.am.coverage
+++ b/Makefile.am.coverage
@@ -1,0 +1,27 @@
+
+# Coverage targets
+
+if HAVE_GCOV
+
+.PHONY: clean-gcda
+clean-gcda:
+	@echo Removing old coverage results
+	-find -name '*.gcda' -print | xargs -r rm
+
+.PHONY: coverage-html generate-coverage-html clean-coverage-html
+coverage-html: clean-gcda
+	-$(MAKE) $(AM_MAKEFLAGS) -k check
+	$(MAKE) $(AM_MAKEFLAGS) generate-coverage-html
+
+generate-coverage-html:
+	@echo Collecting coverage data
+	$(LCOV) --directory $(top_builddir) --capture --output-file coverage.info --no-checksum --compat-libtool
+	LANG=C $(GENHTML) --prefix $(top_builddir) --output-directory coveragereport --title "Code Coverage" --legend --show-details coverage.info
+
+clean-coverage-html: clean-gcda
+	-$(LCOV) --directory $(top_builddir) -z
+	-rm -rf coverage.info coveragereport
+
+clean-local: clean-coverage-html
+
+endif # HAVE_GCOV

--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ Examples
 --------
 
 C language examples are in the `examples/` directory.
+
+Coverage
+--------
+
+To generate a test coverage report:
+
+* install gcov
+* compile and install as above, adding a flag:
+
+```
+    $ ./autogen.sh  
+    $ ./configure --enable-gcov  
+    $ make  
+    $ make coverage-html
+```
+* inspect the report in `./coveragereport/index.html`

--- a/configure.ac
+++ b/configure.ac
@@ -29,13 +29,23 @@ else
     AC_MSG_ERROR([pkg-config is required!])
 fi
 
-my_CFLAGS="-Wall \
+m4_include([m4/gcov.m4])
+AC_TDD_GCOV
+AC_SUBST(COVERAGE_CFLAGS)
+AC_SUBST(COVERAGE_LDFLAGS)
+
+CFLAGS="-Wall \
 -Wmissing-declarations -Wmissing-prototypes \
 -Wnested-externs -Wpointer-arith \
 -Wpointer-arith -Wsign-compare -Wchar-subscripts \
 -Wstrict-prototypes -Wshadow \
--Wformat-security"
-AC_SUBST([my_CFLAGS])
+-Wformat-security \
+$COVERAGE_CFLAGS \
+"
+AC_SUBST([CFLAGS])
+
+LDFLAGS="$COVERAGE_LDFLAGS"
+AC_SUBST([LDFLAGS])
 
 AC_CHECK_HEADERS([alloca.h])
 

--- a/m4/gcov.m4
+++ b/m4/gcov.m4
@@ -1,4 +1,4 @@
-# Copyright 2012 Canonical Ltd.
+# Copyright 2012 Canonical Ltd., 2018 Farsight Security Inc.
 #
 # This program is free software: you can redistribute it and/or modify it 
 # under the terms of the GNU General Public License version 3, as published 

--- a/m4/gcov.m4
+++ b/m4/gcov.m4
@@ -1,0 +1,91 @@
+# Copyright 2012 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it 
+# under the terms of the GNU General Public License version 3, as published 
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but 
+# WITHOUT ANY WARRANTY; without even the implied warranties of 
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR 
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along 
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Checks for existence of coverage tools:
+#  * gcov
+#  * lcov
+#  * genhtml
+#  * gcovr
+# 
+# Sets ac_cv_check_gcov to yes if tooling is present
+# and reports the executables to the variables LCOV, GCOVR and GENHTML.
+AC_DEFUN([AC_TDD_GCOV],
+[
+  AC_ARG_ENABLE(gcov,
+  AS_HELP_STRING([--enable-gcov],
+		 [enable coverage testing with gcov]),
+  [use_gcov=yes], [use_gcov=no])
+
+  AM_CONDITIONAL(HAVE_GCOV, test "x$use_gcov" = "xyes")
+
+  if test "x$use_gcov" = "xyes"; then
+  # we need gcc:
+  if test "$GCC" != "yes"; then
+    AC_MSG_ERROR([GCC is required for --enable-gcov])
+  fi
+
+  # Check if ccache is being used
+  AC_CHECK_PROG(SHTOOL, shtool, shtool)
+  if test "$SHTOOL"; then
+    AS_CASE([`$SHTOOL path $CC`],
+                [*ccache*], [gcc_ccache=yes],
+                [gcc_ccache=no])
+  fi
+
+  if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
+    AC_MSG_ERROR([ccache must be disabled when --enable-gcov option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
+  fi
+
+  lcov_version_list="1.6 1.7 1.8 1.9 1.13"
+  AC_CHECK_PROG(LCOV, lcov, lcov)
+  AC_CHECK_PROG(GENHTML, genhtml, genhtml)
+
+  if test "$LCOV"; then
+    AC_CACHE_CHECK([for lcov version], glib_cv_lcov_version, [
+      glib_cv_lcov_version=invalid
+      lcov_version=`$LCOV -v 2>/dev/null | $SED -e 's/^.* //'`
+      for lcov_check_version in $lcov_version_list; do
+        if test "$lcov_version" = "$lcov_check_version"; then
+          glib_cv_lcov_version="$lcov_check_version (ok)"
+        fi
+      done
+    ])
+  else
+    lcov_msg="To enable code coverage reporting you must have one of the following lcov versions installed: $lcov_version_list"
+    AC_MSG_ERROR([$lcov_msg])
+  fi
+
+  case $glib_cv_lcov_version in
+    ""|invalid[)]
+      lcov_msg="You must have one of the following versions of lcov: $lcov_version_list (found: $lcov_version)."
+      AC_MSG_ERROR([$lcov_msg])
+      LCOV="exit 0;"
+      ;;
+  esac
+
+  if test -z "$GENHTML"; then
+    AC_MSG_ERROR([Could not find genhtml from the lcov package])
+  fi
+
+  # Remove all optimization flags from CFLAGS
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
+
+  # Add the special gcc flags
+  COVERAGE_CFLAGS="--coverage"
+  COVERAGE_CXXFLAGS="--coverage"	
+  COVERAGE_LDFLAGS="-lgcov"
+
+fi
+]) # AC_TDD_GCOV
+


### PR DESCRIPTION
Offering for @reedjc 's review, WIP--specifically I was confused by my_CFLAGS and so my edit there is probably not necessary if you're able to explain the deep autotools mystery of how the CFLAGS get added selectively to the build.

Use the README.md to take for a spin.

In past deployments the addition of the gcov dependency to the Debian build has caused some headaches, I wonder if you can suggest a workaround?

Started this branch before I gained FSI perms, can re-propose once we've talked through the above.