### PR TITLE
Support SVCB and HTTPS RRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 Makefile
 Makefile.in
 TAGS
+tags
+cscope.out
 wdns/libwdns.pc
 wdns/rcode_to_str.c
 wdns/rrclass_to_str.c
@@ -31,5 +33,8 @@ t/test-str_to_rcode
 t/test-str_to_rdata
 t/test-str_to_rrtype
 t/test-rdata_to_str
+t/test-name_to_str
 t/*.log
 t/*.trs
+examples/wdns-print-version
+wdns/wdns.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,6 +147,7 @@ wdns_libwdns_la_SOURCES = \
 	wdns/skip_name.c \
 	wdns/str_to_name.c \
 	wdns/str_to_rdata_ubuf.c \
+	wdns/svcparamkeys_to_str.c \
 	wdns/unpack_name.c \
 	wdns/version.c
 

--- a/t/test-rdata_to_str.c
+++ b/t/test-rdata_to_str.c
@@ -62,13 +62,13 @@ struct test tdata[] = {
 	/* TXT test for: one quote sent over the wire */
 	{
 		.input = "\x03" "one" "\x05" "quote" "\x01" "\"" "\x04" "sent" "\x04" "over" "\x03" "the" "\x04" "wire",
-		.input_len = 1 + 3 + 1 + 5 + 1 + 1 + 1 + 4 + 1 + 4 + 1 + 3 + 1 + 4, 
+		.input_len = 1 + 3 + 1 + 5 + 1 + 1 + 1 + 4 + 1 + 4 + 1 + 3 + 1 + 4,
 		.rrtype = WDNS_TYPE_TXT,
 		.rrclass = WDNS_CLASS_IN,
 		.expected = "\"one\" \"quote\" \"\\\"\" \"sent\" \"over\" \"the\" \"wire\"",
 	},
 
-	/* TXT test for: 256 characters in length (including the length 
+	/* TXT test for: 256 characters in length (including the length
 	   octet) */
 	{
 		.input = "\xff" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -274,6 +274,38 @@ struct test tdata[] = {
 		.rrtype = WDNS_TYPE_NSEC,
 		.rrclass = WDNS_CLASS_IN,
 		.expected = "fsi.io. A CAA DLV",
+	},
+
+	/* HTTPS test */
+	{
+		.input = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02\x68\x32"	/* length-value */
+		    "\x00\x04"		/* ipv4hint in network order */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x01",	/* ipv4hint */
+		.input_len = 18,
+		.rrclass = WDNS_CLASS_IN,
+		.rrtype = WDNS_TYPE_HTTPS,
+		.expected = "1 . alpn=h2 ipv4hint=192.168.0.1",
+	},
+
+	/* HTTPS test for an arbitrary key type 9 */
+	{
+		.input = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02\x68\x32"	/* length-value */
+		    "\x00\x09"		/* key9 in network order */
+		    "\x00\x03"		/* length of key9 in net order */
+		    "\x61\x6e\x79",	/* length-value */
+		.input_len = 17,
+		.rrclass = WDNS_CLASS_IN,
+		.rrtype = WDNS_TYPE_HTTPS,
+		.expected = "1 . alpn=h2 key9=\"any\"",
 	},
 
 	{ 0 }

--- a/t/test-str_to_rdata.c
+++ b/t/test-str_to_rdata.c
@@ -254,6 +254,149 @@ static const struct test tdata[] = {
 	{ "NSEC3 10 3 172800 1443179274 1440584754 25427 go.id. TzGzKBNpQysYIEBHzCMub5PSg6H564xt2c/JYW6fCOyoUesDqECbJHDl 6pgyQaicCrsdSuqImSi1Ej63OEgJ1o5gKUQh0brq7i8oDZ343M57j9O7 hk7Hm+066r2dEKAD2c0SKeFTdOhjWk01Opkw+DW0SbhvKbsngII3e5mb y7+uSW3TH0OX/nOZMte8F1z98UyGKjRsInlXfc4nh2TknrwvGFgRZoS1 X2PWLkzVQSjGsfLS1/N01TYVGe0IyDWoY6csNQhnSS53Z1WAIZOuSoV5 oBBCQIQFDjknqT9/YkqQNCJso0xGcr2CyQHKcVduxYGgVarEABANrDQV DxpuEeaYGS7+eGJT+sznItOTQeSSYougSu6DsxVwYyTix/alO+KpUwzP 7YZBJIssnHYdqUvXQlcxpYtlhEYcISlcP5Ate/A2hoDR+KXo1+6ydBUy gmNTLRYVX7N+ajRnBIAhAoaGotpgzUe3uZIoiKi8FY/L4glE93mFCBqb +4mJ7O5rtWlnHy9jMlW9AIzoqfDmLoNaTUF1D6mdkVU5Gs+E0gST6Mln arJtIHttDLz/GZMOnd79+GKTdKUr5Ch4QP5LALys6WDWa2EdUg2ZWH5m hqU+5XQDMcOFyeyLsqudy4DkXk2rFMtGQlU0crzaKKyf+qSeMbXMda1F GU+kwrQvgtE=", WDNS_TYPE_RRSIG, WDNS_CLASS_IN, "\x00""2\x0a\x03\x00\x02\xa3\x00V\x05+\x0aU\xdd\x94""2cS\x02go\x02id\x00O1\xb3(\x13iC+\x18 @G\xcc#.o\x93\xd2\x83\xa1\xf9\xeb\x8cm\xd9\xcf\xc9""an\x9f\x08\xec\xa8Q\xeb\x03\xa8@\x9b$p\xe5\xea\x98""2A\xa8\x9c\x0a\xbb\x1dJ\xea\x88\x99(\xb5\x12>\xb7""8H\x09\xd6\x8e`)D!\xd1\xba\xea\xee/(\x0d\x9d\xf8\xdc\xce{\x8f\xd3\xbb\x86N\xc7\x9b\xed:\xea\xbd\x9d\x10\xa0\x03\xd9\xcd\x12)\xe1St\xe8""cZM5:\x99""0\xf8""5\xb4I\xb8o)\xbb'\x80\x82""7{\x99\x9b\xcb\xbf\xaeIm\xd3\x1f""C\x97\xfes\x99""2\xd7\xbc\x17\\\xfd\xf1L\x86*4l\"yW}\xce'\x87""d\xe4\x9e\xbc/\x18X\x11""f\x84\xb5_c\xd6.L\xd5""A(\xc6\xb1\xf2\xd2\xd7\xf3t\xd5""6\x15\x19\xed\x08\xc8""5\xa8""c\xa7,5\x08gI.wgU\x80!\x93\xaeJ\x85y\xa0\x10""B@\x84\x05\x0e""9'\xa9?\x7f""bJ\x90""4\"l\xa3LFr\xbd\x82\xc9\x01\xcaqWn\xc5\x81\xa0U\xaa\xc4\x00\x10\x0d\xac""4\x15\x0f\x1an\x11\xe6\x98\x19.\xfexbS\xfa\xcc\xe7\"\xd3\x93""A\xe4\x92""b\x8b\xa0J\xee\x83\xb3\x15pc$\xe2\xc7\xf6\xa5;\xe2\xa9S\x0c\xcf\xed\x86""A$\x8b,\x9cv\x1d\xa9K\xd7""BW1\xa5\x8b""e\x84""F\x1c!)\\?\x90-{\xf0""6\x86\x80\xd1\xf8\xa5\xe8\xd7\xee\xb2t\x15""2\x82""cS-\x16\x15_\xb3~j4g\x04\x80!\x02\x86\x86\xa2\xda`\xcdG\xb7\xb9\x92(\x88\xa8\xbc\x15\x8f\xcb\xe2\x09""D\xf7y\x85\x08\x1a\x9b\xfb\x89\x89\xec\xeek\xb5ig\x1f/c2U\xbd\x00\x8c\xe8\xa9\xf0\xe6.\x83ZMAu\x0f\xa9\x9d\x91U9\x1a\xcf\x84\xd2\x04\x93\xe8\xc9gj\xb2m {m\x0c\xbc\xff\x19\x93\x0e\x9d\xde\xfd\xf8""b\x93t\xa5+\xe4(x@\xfeK\x00\xbc\xac\xe9`\xd6ka\x1dR\x0d\x99X~f\x86\xa5>\xe5t\x03""1\xc3\x85\xc9\xec\x8b\xb2\xab\x9d\xcb\x80\xe4^M\xab\x14\xcb""FBU4r\xbc\xda(\xac\x9f\xfa\xa4\x9e""1\xb5\xccu\xad""E\x19O\xa4\xc2\xb4/\x82\xd1", 537, wdns_res_success },
 	/* generic encodings */
 	{ "\\# 24 d5 79 08 01 98 4e d2 96 9a 76 0c f6 09 8e a1 4a 84 65 16 9c aa 9c 48 07", 32769, WDNS_CLASS_IN, "\xd5\x79\x08\x01\x98\x4e\xd2\x96\x9a\x76\x0c\xf6\x09\x8e\xa1\x4a\x84\x65\x16\x9c\xaa\x9c\x48\x07", 24, wdns_res_success },
+
+	/* HTTPS tests */
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . alpn=h2",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h2",		/* length-value */
+		.expected_len = 10,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . alpn=h2,h3",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h2"		/* length-value */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h3",		/* length-value */
+		.expected_len = 15,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . alpn=h2,h3 no-default-alpn",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h2"		/* length-value */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h3"		/* length-value */
+		    "\x00\x02",
+		.expected_len = 17,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . port=1111",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x03"		/* port key in network order */
+		    "\x04W",		/* port value in network order */
+		.expected_len = 7,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . ipv4hint=192.168.0.1",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x04"		/* ipv4hint in network order */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x01",	/* ipv4hint */
+		.expected_len = 11,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . ipv4hint=192.168.0.1,192.168.0.2",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x04"		/* ipv4hint in network order */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x01"	/* ipv4hint */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x02",	/* ipv4hint */
+		.expected_len = 17,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . ipv6hint=2001:1:2:3:4:5:6:7",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x06"		/* ipv6hint in network order */
+		    "\x00\x10"		/* length of ipv6hint in net order */
+		    " \x01\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07",/* ipv6hint */
+		.expected_len = 23,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . echconfig=abcdefghijkl",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x05"		/* echconfig key in network order */
+		    "i\xb7\x1dy\xf8!\x8a""""9%",	/* echconfig value */
+		.expected_len = 14,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . mandatory=port alpn=h2,h3 port=1111"
+		    " ipv4hint=192.168.0.1,192.168.0.2"
+		    " ipv6hint=2001:1:2:3:4:5:6:7",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x00"		/* mandatory key */
+		    "\x00\x03"		/* port key in network order */
+		    "\x00\x01"		/* alpn in network order */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h2"		/* length-value */
+		    "\x00\x03"		/* length of the alpnid in net order */
+		    "\x02h3"		/* length-value */
+		    "\x00\x03"		/* port key in network order */
+		    "\x04W"		/* port value in network order */
+		    "\x00\x04"		/* ipv4hint in network order */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x01"	/* ipv4hint */
+		    "\x00\x04"		/* length of ipv4hint in net order */
+		    "\xc0\xa8\x00\x02"	/* ipv4hint */
+		    "\x00\x06"		/* ipv6hint in network order */
+		    "\x00\x10"		/* length of ipv6hint in net order */
+		    " \x01\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07",/* ipv6hint */
+		.expected_len = 57,
+		.expected_res = wdns_res_success,
+	},
+	{
+		.rrtype = WDNS_TYPE_HTTPS,
+		.rrclass = WDNS_CLASS_IN,
+		.input = "1 . key10=222",
+		.expected = "\x00\x01"	/* SvcPriority */
+		    "\x00"		/* Target */
+		    "\x00\x0a"		/* '10' in network order */
+		    "\x03""""222",	/* '222' value */
+		.expected_len = 9,
+		.expected_res = wdns_res_success,
+	},
+
 	{ 0 }
 };
 

--- a/wdns/downcase_rdata.c
+++ b/wdns/downcase_rdata.c
@@ -79,6 +79,7 @@ wdns_downcase_rdata(wdns_rdata_t *rdata, uint16_t rrtype, uint16_t rrclass)
 			case rdf_bytes_b64:
 			case rdf_bytes_str:
 			case rdf_type_bitmap:
+			case rdf_svcparams:
 				return (wdns_res_success);
 
 			case rdf_int8:

--- a/wdns/record_descr.c
+++ b/wdns/record_descr.c
@@ -210,7 +210,38 @@ const record_descr record_descr_array[] = {
 			rdf_bytes_str,	/* Target */
 			rdf_end,
 		}
+	},
 
+	/* draft-ietf-dnsop-svcb-https */
+	[WDNS_TYPE_SVCB] = {	/* used to locate alt endpoints for a service */
+		class_in,
+		{
+			rdf_int16,	/* SvcPriority: The priority of this
+					   record (relative to others, with
+					   lower values preferred). A value of
+					   0 indicates AliasMode */
+			rdf_name,	/* TargetName: The domain name of either
+					   the alias target (for AliasMode) or
+					   the alternative endpoint (for
+					   ServiceMode) */
+			rdf_svcparams,	/* SvcParams (optional): A list of
+					   key=value pairs describing the
+					   alternative endpoint at TargetName
+					   (only used in ServiceMode and
+					   otherwise ignored). */
+			rdf_end,
+		}
+	},
+
+	/* draft-ietf-dnsop-svcb-https */
+	[WDNS_TYPE_HTTPS] = {	/* a SVCB-compatible RR type for HTTPS */
+		class_in,
+		{
+			rdf_int16,	/* SvcFieldPriority*/
+			rdf_name,	/* SvcDomainName*/
+			rdf_svcparams,	/* SvcFieldValue */
+			rdf_end,
+		}
 	},
 };
 

--- a/wdns/record_descr.h
+++ b/wdns/record_descr.h
@@ -29,7 +29,8 @@ typedef enum {
 	rdf_type_bitmap,/* rr type bitmap */
 	rdf_salt,	/* length-prefixed salt value (hex presentation) */
 	rdf_hash,	/* length-prefixed hash value (base32 presentation) */
-	rdf_end		/* sentinel (terminal) */
+	rdf_svcparams,	/* list of space separated key=value pairs */
+	rdf_end,	/* sentinel (terminal) */
 } rdf_type;
 
 typedef struct {
@@ -39,5 +40,42 @@ typedef struct {
 
 extern const record_descr	record_descr_array[];
 extern const size_t		record_descr_len;
+
+/*
+ * Service Binding (SVCB) Parameter Registry
+ */
+typedef enum {
+	spr_mandatory = 0,
+
+	/*
+	 * The "alpn" and "no-default-alpn" SvcParamKeys together indicate the
+	 * set of Application Layer Protocol Negotiation (ALPN) protocol
+	 * identifiers [ALPN] and associated transport protocols supported by
+	 * this service endpoint.
+	 */
+	spr_alpn = 1,
+	spr_nd_alpn = 2,
+
+	/*
+	 * TCP or UDP port that should be used to reach this alternative
+	 * endpoint. If this key is not present, clients SHALL use the
+	 * authority endpoint's port number.
+	 */
+	spr_port = 3,
+
+	/* Encrypted ClientHello info */
+	spr_echconfig = 5,
+
+	/*
+	 * The "hint" keys convey IP addresses that clients MAY use to reach
+	 * the service.
+	 */
+	spr_ipv4hint = 4,
+	spr_ipv6hint = 6,
+
+	/* Reserved ("Invalid Key") */
+	spr_invalid = 65535,
+
+} svcb_svcparam_keys;
 
 #endif /* WDNS_RECORD_DESCR_H */

--- a/wdns/svcparamkeys_to_str.c
+++ b/wdns/svcparamkeys_to_str.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 Farsight Security, Inc.
+ *
+ * Helper routines for values in the Service Binding (SVCB) Parameter Registry.
+ */
+char *
+_wdns_svcparamkey_to_str(uint16_t key, char *buf, size_t len)
+{
+	switch (key) {
+	case spr_mandatory:
+		return (strncpy(buf, "mandatory", len));
+
+	case spr_alpn:
+		return (strncpy(buf, "alpn", len));
+
+	case spr_nd_alpn:
+		return (strncpy(buf, "no-default-alpn", len));
+
+	case spr_port:
+		return (strncpy(buf, "port", len));
+
+	case spr_echconfig:
+		return (strncpy(buf, "echconfig", len));
+
+	case spr_ipv4hint:
+		return (strncpy(buf, "ipv4hint", len));
+
+	case spr_ipv6hint:
+		return (strncpy(buf, "ipv6hint", len));
+
+	case spr_invalid:
+		return (strncpy(buf, "invalid key", len));
+
+	default:
+		if (snprintf(buf, len, "key%hu", key) > 0) {
+			return (buf);
+		}
+	}
+
+	return (NULL);
+}
+
+uint16_t
+_wdns_str_to_svcparamkey(char *str)
+{
+	if (strcmp(str, "mandatory") == 0) {
+		return (spr_mandatory);
+	} else if (strcmp(str, "alpn") == 0) {
+		return (spr_alpn);
+	} else if (strcmp(str, "no-default-alpn") == 0) {
+		return (spr_nd_alpn);
+	} else if (strcmp(str, "port") == 0) {
+		return (spr_port);
+	} else if (strcmp(str, "echconfig") == 0) {
+		return (spr_echconfig);
+	} else if (strcmp(str, "ipv4hint") == 0) {
+		return (spr_ipv4hint);
+	} else if (strcmp(str, "ipv6hint") == 0) {
+		return (spr_ipv6hint);
+	} else if (strncmp(str, "key", 3) == 0 && strlen(str) > 3) {
+		/* parse an arbitrary key */
+		unsigned long int key;
+		char *endp;
+
+		key = (uint16_t)strtoul(str + strlen("key"), &endp, 10);
+
+		if (*endp != '\0' || key >= (unsigned long int)spr_invalid) {
+			return (spr_invalid);
+		}
+
+		if (key < spr_invalid) {
+			return (key);
+		}
+	}
+
+	return (spr_invalid);
+}

--- a/wdns/wdns-private.h
+++ b/wdns/wdns-private.h
@@ -109,3 +109,9 @@ _wdns_rrset_to_ubuf(ubuf *, wdns_rrset_t *rrset, unsigned sec);
 
 void
 _wdns_rrset_array_to_ubuf(ubuf *, wdns_rrset_array_t *a, unsigned sec);
+
+uint16_t
+_wdns_str_to_svcparamkey(char *str);
+
+char *
+_wdns_svcparamkey_to_str(uint16_t key, char *buf, size_t len);

--- a/wdns/wdns.h.in
+++ b/wdns/wdns.h.in
@@ -126,7 +126,10 @@ extern "C" {
 #define WDNS_TYPE_CDNSKEY	60
 #define WDNS_TYPE_OPENPGPKEY	61
 #define WDNS_TYPE_CSYNC		62
-/* Unassigned: 63 - 98 */
+/* Unassigned: 63 */
+#define	WDNS_TYPE_SVCB		64
+#define	WDNS_TYPE_HTTPS		65
+/* Unassigned: 66 - 98 */
 #define WDNS_TYPE_SPF		99
 #define WDNS_TYPE_UINFO		100
 #define WDNS_TYPE_UID		101


### PR DESCRIPTION
Adding support of SVCB and HTTPS bindings per https://datatracker.ietf.org/doc/draft-ietf-dnsop-svcb-https/?include_text=1