### PR TITLE
Deprecate python2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wdns (0.10.0-2) debian-fsi; urgency=medium
+
+  * Migrate to Python3 for gen_*, required for building.
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Tue, 08 Feb 2022 00:58:15 +0000
+
 wdns (0.10.0-1) debian-fsi; urgency=medium
 
   * New release.

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
  dpkg-dev (>= 1.16.0~),
  lcov,
  pkg-config,
- python,
+ python3,
 Standards-Version: 3.9.8
 
 Package: libwdns-dev

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: 2009-2019 by Farsight Security, Inc.
+Copyright: 2009-2022 by Farsight Security, Inc.
 License: Apache-2.0
  Licensed under the Apache License, Version 2.0 (the "License"); you
  may not use this file except in compliance with the License. You may
@@ -15,7 +15,7 @@ License: Apache-2.0
  implied. See the License for the specific language governing
  permissions and limitations under the License.
  .
- On Debian systems, the full text of the Apache Licens, Version 2.0 can be
+ On Debian systems, the full text of the Apache License, Version 2.0 can be
  found in the file `/usr/share/common-licenses/Apache-2.0'.
 
 Files: libmy/b32_encode.c libmy/b32_encode.h libmy/b32_decode.c libmy/b32_decode.h


### PR DESCRIPTION
Needing this to provide for current Debian; we'd benefit from a thorough review of the wdns/gen_* scripts, which are involved in the build; note that 2to3 pulls nothing but makes some suggestions.