### PR TITLE
Add edns info to wdns_msg_to_str()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ wdns_libwdns_la_SOURCES = \
 	wdns/downcase_name.c \
 	wdns/downcase_rdata.c \
 	wdns/downcase_rrset.c \
+	wdns/edns_options.c \
 	wdns/file_load_names.c \
 	wdns/insert_rr_rrset_array.c \
 	wdns/is_subdomain.c \

--- a/wdns/edns_options.c
+++ b/wdns/edns_options.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2023 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* IANA Address Family Numbers */
+typedef enum {
+	ip = 1,
+	ip6 = 2,
+} iana_addr_family_numbers;
+
+/* EDNS0 Option Codes (OPT)*/
+typedef enum {
+	llq = 1,
+	nsid = 3,
+	dau = 5,
+	dhu = 6,
+	n3u = 7,
+	edns_client_subnet = 8,
+	edns_expire = 9,
+	cookie = 10,
+	edns_tcp_keepalive = 11,
+	padding = 12,
+	chain = 13,
+	edns_key_tag = 14,
+	extended_dns_error = 15,
+	edns_client_tag = 16,
+	edns_server_tag = 17,
+	/* 18-20291 Unassigned */
+	umbrella_ident = 20292,
+	/* 20293-26945 Unassigned */
+	deviceid = 26946,
+	/* 26947-65000 Unassigned */
+	/* 65001-65534 Reserved for Local/Experimental Use */
+	reserved_for_future_expansion = 65535,
+} edns0_option_codes;
+
+/*
+ * See RFC 8914 Section 5.2
+ * [INFO-CODE] = "Purpose"
+ */
+const char * ede_purpose_array[] = {
+	[0] = "Other Error",
+	[1] = "Unsupported DNSKEY Algorithm",
+	[2] = "Unsupported DS Digest Type",
+	[3] = "Stale Answer",
+	[4] = "Forged Answer",
+	[5] = "DNSSEC Indeterminate",
+	[6] = "DNSSEC Bogus",
+	[7] = "Signature Expired",
+	[8] = "Signature Not Yet Valid",
+	[9] = "DNSKEY Missing",
+	[10] = "RRSIGs Missing",
+	[11] = "No Zone Key Bit Set",
+	[12] = "NSEC Missing",
+	[13] = "Cached Error",
+	[14] = "Not Ready",
+	[15] = "Blocked",
+	[16] = "Censored",
+	[17] = "Filtered",
+	[18] = "Prohibited",
+	[19] = "Stale NXDomain Answer",
+	[20] = "Not Authoritative",
+	[21] = "Not Supported",
+	[22] = "No Reachable Authority",
+	[23] = "Network Error",
+	[24] = "Invalid Data",
+	/* 25-49151 Unassigned */
+	/* 49152-65535 Reserved for Private Use */
+};
+
+const size_t ede_purpose_array_len = sizeof(ede_purpose_array) / sizeof(char *);
+
+static inline wdns_res
+ip_to_ubuf(ubuf *u, uint16_t addr_family, const uint8_t *src, uint16_t src_bytes) {
+	char pres[WDNS_PRESLEN_TYPE_AAAA];
+	uint8_t addr[16] = {0};
+
+	if (src_bytes == 0) {
+		return (wdns_res_parse_error);
+	} else if (addr_family != ip && addr_family != ip6) {
+		return (wdns_res_parse_error);
+	} else if (addr_family == ip && src_bytes > 4) {
+		return (wdns_res_parse_error);
+	} else if (addr_family == ip6 && src_bytes > 16) {
+		return (wdns_res_parse_error);
+	}
+
+	memcpy(addr, src, src_bytes);
+	inet_ntop((addr_family == ip ? AF_INET : AF_INET6), addr, pres, sizeof(pres));
+	ubuf_add_cstr(u, pres);
+	return (wdns_res_success);
+}
+
+/*
+ * Helper routine for adding EDNS0 Option Codes to a ubuf in the format of dig.
+ */
+void
+_wdns_ednsoptcode_to_ubuf(ubuf *u, uint16_t option_code)
+{
+	ubuf_add_cstr(u, "\n; ");
+	switch (option_code) {
+		case edns_client_subnet:
+			ubuf_add_cstr(u, "CLIENT-SUBNET:");
+			break;
+		case extended_dns_error:
+			ubuf_add_cstr(u, "EDE:");
+			break;
+		default:
+			ubuf_add_fmt(u, "OPT=%u:", option_code);
+			break;
+	}
+}
+
+/*
+ * Helper routine for adding EDNS0 Option Data to a ubuf in the format of dig.
+ */
+wdns_res
+_wdns_ednsoptdata_to_ubuf(ubuf *u, uint16_t option_code, const uint8_t *src, uint16_t src_bytes)
+{
+
+#define bytes_required(n) do { \
+	if (src_bytes < ((signed) (n))) \
+		goto err; \
+} while(0)
+
+#define bytes_consumed(n) do { \
+	src += n; \
+	src_bytes -= n; \
+} while(0)
+
+#define print_printable(u, src, src_bytes) do { \
+	for (uint16_t i = 0; i < src_bytes; i++) { \
+		char c = isprint(src[i]) ? src[i] : '.'; \
+		ubuf_add_fmt(u, "%c", c); \
+	} \
+} while(0)
+
+	ubuf_add_cstr(u, " ");
+	switch (option_code) {
+		case edns_client_subnet: {
+			wdns_res res;
+			uint16_t addr_family_num;
+			uint8_t source_prefix_len, scope_prefix_len;
+
+			/*
+			 * RFC 7871. The first two octets in network byte order
+			 * indicates the iana address family of the address
+			 * contained in this option. The next two octets
+			 * represent the Source Prefix-Length and Scope
+			 * Prefix-Length respectively.
+			 */
+			bytes_required(sizeof(addr_family_num));
+			memcpy(&addr_family_num, src, sizeof(addr_family_num));
+			addr_family_num = ntohs(addr_family_num);
+			bytes_consumed(sizeof(addr_family_num));
+
+			bytes_required(sizeof(source_prefix_len));
+			memcpy(&source_prefix_len, src, sizeof(source_prefix_len));
+			bytes_consumed(sizeof(source_prefix_len));
+
+			bytes_required(sizeof(scope_prefix_len));
+			memcpy(&scope_prefix_len, src, sizeof(scope_prefix_len));
+			bytes_consumed(sizeof(scope_prefix_len));
+
+			/* Add the address to the ubuf in presentation format */
+			res = ip_to_ubuf(u, addr_family_num, src, src_bytes);
+			if (res != wdns_res_success) {
+				goto err;
+			}
+			bytes_consumed(src_bytes);
+
+			/*
+			 * Finally, dig displays the source and scope prefix lens after
+			 * the address.
+			 */
+			ubuf_add_fmt(u, "/%u/%u", source_prefix_len, scope_prefix_len);
+			break;
+		}
+		case extended_dns_error: {
+			uint16_t info_code;
+
+			/*
+			 * RFC 8914. The first two octets encoded in network
+			 * byte order represents the INFO-CODE which is an
+			 * index into the "Extended DNS Errors" registry.
+			 */
+			bytes_required(sizeof(info_code));
+			memcpy(&info_code, src, sizeof(info_code));
+			info_code = ntohs(info_code);
+			bytes_consumed(sizeof(info_code));
+			ubuf_add_fmt(u, "%u", info_code);
+
+			/*
+			 * Display the purpose string of info-codes that
+			 * can be found in Section 5.2 of RFC 8914.
+			 */
+			if (info_code < ede_purpose_array_len) {
+				ubuf_add_fmt(u, " (%s)", ede_purpose_array[info_code]);
+			}
+
+			/*
+			 * Display the remaining octets enclosed without quotes
+			 * in parenthesis with printable octets printed and
+			 * non-printable octets represented as dots.
+			 */
+			ubuf_add_cstr(u, ": (");
+			print_printable(u, src, src_bytes);
+			ubuf_add_cstr(u, ")");
+			break;
+		}
+		default:
+			/*
+			 * Default dig behavior of printing each octet's hex
+			 * value separated by spaces.
+			 */
+			for (uint16_t i = 0; i < src_bytes; i++)
+				ubuf_add_fmt(u, "%02x ", src[i]);
+			/*
+			 * Followed by the same sequence repeated and enclosed
+			 * in parenthesis and quotes except now printable
+			 * octets are printed and non-printable octets are
+			 * represented as dots.
+			 */
+			ubuf_add_cstr(u, "(\"");
+			print_printable(u, src, src_bytes);
+			ubuf_add_cstr(u, "\")");
+			break;
+	}
+	return (wdns_res_success);
+
+err:
+	return (wdns_res_parse_error);
+#undef bytes_required
+#undef bytes_consumed
+#undef print_printable
+}

--- a/wdns/message_to_str.c
+++ b/wdns/message_to_str.c
@@ -57,9 +57,22 @@ wdns_message_to_str(wdns_message_t *m)
 		     m->sections[3].n_rrs
 	);
 
+	if (m->edns.present) {
+		char *edns_flags = m->edns.flags & 0x8000 ? " do" : "";
+		ubuf_add_cstr(u, "\n;; OPT PSEUDOSECTION:");
+		/*
+		 * RFC 6891 Section 6.1.4 and RFC 3225. Display "do" flag
+		 * if the "DNSSEC OK" (D0) bit is set.
+		 */
+		ubuf_add_fmt(u, "\n; EDNS: version: %u, flags:%s; udp: %u", m->edns.version,
+			edns_flags, m->edns.size);
+		if (m->edns.options != NULL) {
+			_wdns_rdata_to_ubuf(u, m->edns.options->data,
+				m->edns.options->len, WDNS_TYPE_OPT, class_un);
+		}
+	}
 	ubuf_add_cstr(u, "\n;; QUESTION SECTION:\n");
 	_wdns_rrset_array_to_ubuf(u, &m->sections[WDNS_MSG_SEC_QUESTION], WDNS_MSG_SEC_QUESTION);
-
 	ubuf_add_cstr(u, "\n;; ANSWER SECTION:\n");
 	_wdns_rrset_array_to_ubuf(u, &m->sections[WDNS_MSG_SEC_ANSWER], WDNS_MSG_SEC_ANSWER);
 

--- a/wdns/parse_rdata.c
+++ b/wdns/parse_rdata.c
@@ -180,6 +180,7 @@ _wdns_parse_rdata(wdns_rr_t *rr, const uint8_t *p, const uint8_t *eop,
 			case rdf_bytes:
 			case rdf_bytes_b64:
 			case rdf_bytes_str:
+			case rdf_edns_opt_rdata:
 				copy_bytes(src_bytes);
 				break;
 

--- a/wdns/record_descr.c
+++ b/wdns/record_descr.c
@@ -279,6 +279,15 @@ const record_descr record_descr_array[] = {
 			rdf_end,
 		}
 	},
+
+	[WDNS_TYPE_OPT] = {
+		class_un,
+		{
+			rdf_edns_opt_rdata,
+			rdf_end,
+		}
+	},
+
 };
 
 const size_t record_descr_len = sizeof(record_descr_array) / sizeof(record_descr);

--- a/wdns/record_descr.h
+++ b/wdns/record_descr.h
@@ -25,28 +25,29 @@ typedef enum {
 } record_class;
 
 typedef enum {
-	rdf_unknown,	/* marker for unpopulated entries */
-	rdf_bytes,	/* byte array (terminal) */
-	rdf_bytes_b64,	/* byte array (terminal) (base64 encoded presentation) */
-	rdf_bytes_str,	/* byte array (terminal) (string representation) */
-	rdf_name,	/* series of labels terminated by zero-length label, possibly compressed */
-	rdf_uname,	/* series of labels terminated by zero-length label, NOT compressed */
-	rdf_int8,	/* 8 bit integer */
-	rdf_int16,	/* 16 bit integer */
-	rdf_int32,	/* 32 bit integer */
-	rdf_ipv4,	/* IPv4 host address */
-	rdf_ipv6,	/* IPv6 host address */
-	rdf_ipv6prefix,	/* IPv6 prefix: length octet followed by 0-16 octets */
-	rdf_eui48,	/* EUI-48 address */
-	rdf_eui64,	/* EUI-64 address */
-	rdf_string,	/* length octet followed by that many octets */
-	rdf_repstring,	/* one or more strings (terminal) */
-	rdf_rrtype,	/* resource record type */
-	rdf_type_bitmap,/* rr type bitmap */
-	rdf_salt,	/* length-prefixed salt value (hex presentation) */
-	rdf_hash,	/* length-prefixed hash value (base32 presentation) */
-	rdf_svcparams,	/* list of space separated key=value pairs */
-	rdf_end,	/* sentinel (terminal) */
+	rdf_unknown,		/* marker for unpopulated entries */
+	rdf_bytes,		/* byte array (terminal) */
+	rdf_bytes_b64,		/* byte array (terminal) (base64 encoded presentation) */
+	rdf_bytes_str,		/* byte array (terminal) (string representation) */
+	rdf_name,		/* series of labels terminated by zero-length label, possibly compressed */
+	rdf_uname,		/* series of labels terminated by zero-length label, NOT compressed */
+	rdf_int8,		/* 8 bit integer */
+	rdf_int16,		/* 16 bit integer */
+	rdf_int32,		/* 32 bit integer */
+	rdf_ipv4,		/* IPv4 host address */
+	rdf_ipv6,		/* IPv6 host address */
+	rdf_ipv6prefix,		/* IPv6 prefix: length octet followed by 0-16 octets */
+	rdf_eui48,		/* EUI-48 address */
+	rdf_eui64,		/* EUI-64 address */
+	rdf_string,		/* length octet followed by that many octets */
+	rdf_repstring,		/* one or more strings (terminal) */
+	rdf_rrtype,		/* resource record type */
+	rdf_type_bitmap,	/* rr type bitmap */
+	rdf_salt,		/* length-prefixed salt value (hex presentation) */
+	rdf_hash,		/* length-prefixed hash value (base32 presentation) */
+	rdf_svcparams,		/* list of space separated key=value pairs */
+	rdf_edns_opt_rdata,	/* byte array of {attribute, value} pairs */
+	rdf_end,		/* sentinel (terminal) */
 } rdf_type;
 
 typedef struct {

--- a/wdns/wdns-private.h
+++ b/wdns/wdns-private.h
@@ -131,3 +131,9 @@ _wdns_str_to_svcparamkey(char *str);
 
 char *
 _wdns_svcparamkey_to_str(uint16_t key, char *buf, size_t len);
+
+void
+_wdns_ednsoptcode_to_ubuf(ubuf *, uint16_t option_code);
+
+wdns_res
+_wdns_ednsoptdata_to_ubuf(ubuf *u, uint16_t option_code, const uint8_t *src, uint16_t src_bytes);


### PR DESCRIPTION
This PR adds showing edns0 data when using `wdns_msg_to_str()`. The format is based on dig version 9.16's format.