### PR TITLE
Fix off-by-one error in wdns_str_to_name

### DIFF
--- a/t/test-str_to_name.c
+++ b/t/test-str_to_name.c
@@ -40,7 +40,23 @@ struct test {
 
 struct test tdata[] = {
 	{ "fsi.io", (fp)wdns_str_to_name, (const uint8_t*)"\x03""fsi\x02io\x00", 8, wdns_res_success},
+	{ "fsi.io.", (fp)wdns_str_to_name, (const uint8_t*)"\x03""fsi\x02io\x00", 8, wdns_res_success},
 	{ "FsI.io", (fp)wdns_str_to_name_case, (const uint8_t*)"\x03""FsI\x02io\x00", 8, wdns_res_success},
+	{ "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x61xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.",
+	  (fp)wdns_str_to_name,
+	  (const uint8_t *)"\x3Fx63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+			   "\x3Fx63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+			   "\x3Fx63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+			   "\x3Dx61xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\x00",
+	  255, wdns_res_success },
+	{ "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x63xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx."
+	  "x62xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.",
+	  (fp)wdns_str_to_name, (const uint8_t *)"", 0, wdns_res_name_overflow },
 	{ 0 }
 };
 
@@ -74,6 +90,10 @@ test_str_to_name(void)
 				escape(u, name.data, name.len);
 			}
 			failures++;
+		} else if (res != wdns_res_success) {
+			ubuf_add_fmt(u, "PASS %" PRIu64 ": input=", cur-tdata);
+			escape(u, (uint8_t*)cur->input, strlen(cur->input));
+			ubuf_add_fmt(u, " res=%s", wdns_res_to_str(res));
 		} else if (name.len != cur->expected_len || memcmp(name.data, cur->expected, name.len)) {
 			ubuf_add_fmt(u, "FAIL %" PRIu64 ": input=", cur-tdata);
 			escape(u, (uint8_t*)cur->input, strlen(cur->input));

--- a/t/test-str_to_name.c
+++ b/t/test-str_to_name.c
@@ -39,6 +39,8 @@ struct test {
 };
 
 struct test tdata[] = {
+	{ "", (fp)wdns_str_to_name, (const uint8_t *)"\x00", 1, wdns_res_success},
+	{ ".", (fp)wdns_str_to_name, (const uint8_t *)"\x00", 1, wdns_res_success},
 	{ "fsi.io", (fp)wdns_str_to_name, (const uint8_t*)"\x03""fsi\x02io\x00", 8, wdns_res_success},
 	{ "fsi.io.", (fp)wdns_str_to_name, (const uint8_t*)"\x03""fsi\x02io\x00", 8, wdns_res_success},
 	{ "FsI.io", (fp)wdns_str_to_name_case, (const uint8_t*)"\x03""FsI\x02io\x00", 8, wdns_res_success},

--- a/wdns/str_to_name.c
+++ b/wdns/str_to_name.c
@@ -120,8 +120,12 @@ _wdns_str_to_name(const char *str, wdns_name_t *name, bool downcase)
 			if (label_len == 0)
 				goto out;
 			oclen = data++;
-			if (slen > 1)
-				name->len++;
+			name->len++;
+			if (slen == 1) {
+				/* trailing '.', end of name */
+				*oclen = 0;
+				break;
+			}
 			label_len = 0;
 		} else if (c != '\0') {
 			*data++ = c;

--- a/wdns/str_to_name.c
+++ b/wdns/str_to_name.c
@@ -36,7 +36,7 @@ _wdns_str_to_name(const char *str, wdns_name_t *name, bool downcase)
 	p = str;
 	slen = strlen(str);
 
-	if (slen == 1 && *p == '.') {
+	if (slen == 0 || (slen == 1 && *p == '.')) {
 		name->len = 1;
 		name->data = my_malloc(1);
 		name->data[0] = '\0';

--- a/wdns/str_to_name.c
+++ b/wdns/str_to_name.c
@@ -25,31 +25,24 @@ is_digit(char c)
 static wdns_res
 _wdns_str_to_name(const char *str, wdns_name_t *name, bool downcase)
 {
-	const char *p;
-	size_t label_len;
+	const char *p = str;
+	size_t label_len = 0;
 	ssize_t slen;
 	uint8_t c, *oclen, *data;
-	wdns_res res;
+	wdns_res res = wdns_res_parse_error;
 
-	res = wdns_res_parse_error;
-
-	p = str;
 	slen = strlen(str);
+	name->len = 1;	/* at least 1 in any possible case */
 
 	if (slen == 0 || (slen == 1 && *p == '.')) {
-		name->len = 1;
 		name->data = my_malloc(1);
 		name->data[0] = '\0';
 		return (wdns_res_success);
 	}
 
-	name->len = 0;
 	name->data = my_malloc(WDNS_MAXLEN_NAME);
-
 	data = name->data;
-	label_len = 0;
 	oclen = data++;
-	name->len++;
 
 	for (;;) {
 		c = *p++;


### PR DESCRIPTION
When parsing a name with a trailing '.', finish parsing at the '.' without additionally processing end of input. Fixes a write beyond the end of the resulting name, which can be unallocated memory for names of maximum length.

Add test cases for maximum length names and name overflow.