### PR TITLE
Move pres format newlines and semicolons to message_to_str function

### DIFF
--- a/t/test-rdata.c
+++ b/t/test-rdata.c
@@ -447,7 +447,7 @@ struct test tdata[] = {
 		.input_len = 11,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET: 199.30.228.0/24/22",
+		.expected = "CLIENT-SUBNET: 199.30.228.0/24/22",
 		.skip_round_trip = true,
 	},
 
@@ -461,7 +461,7 @@ struct test tdata[] = {
 		.input_len = 15,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET: 2620:11c:f008::/56/48",
+		.expected = "CLIENT-SUBNET: 2620:11c:f008::/56/48",
 		.skip_round_trip = true,
 	},
 
@@ -474,7 +474,7 @@ struct test tdata[] = {
 		.input_len = 57,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; EDE: 9 (DNSKEY Missing): (no SEP matching the DS found for dnssec-failed.org.)",
+		.expected = "EDE: 9 (DNSKEY Missing): (no SEP matching the DS found for dnssec-failed.org.)",
 		.skip_round_trip = true,
 	},
 
@@ -487,7 +487,7 @@ struct test tdata[] = {
 		.input_len = 53,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; EDE: 49152: (These chars are printable. These are not:......)",
+		.expected = "EDE: 49152: (These chars are printable. These are not:......)",
 		.skip_round_trip = true,
 	},
 
@@ -501,7 +501,7 @@ struct test tdata[] = {
 		.input_len = 12,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; OPT=6: 01 02 04 (\"...\")\n; OPT=7: 01 (\".\")",
+		.expected = "OPT=6: 01 02 04 (\"...\")\nOPT=7: 01 (\".\")",
 		.skip_round_trip = true,
 	},
 
@@ -512,7 +512,7 @@ struct test tdata[] = {
 		.input_len = 4,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; OPT=5: ### PARSE ERROR ###",
+		.expected = "OPT=5: ### PARSE ERROR ###",
 		.skip_round_trip = true,
 	},
 
@@ -526,7 +526,7 @@ struct test tdata[] = {
 		.input_len = 10,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET: ### PARSE ERROR ###",
+		.expected = "CLIENT-SUBNET: ### PARSE ERROR ###",
 		.skip_round_trip = true,
 	},
 
@@ -540,7 +540,7 @@ struct test tdata[] = {
 		.input_len = 8,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET: ### PARSE ERROR ###",
+		.expected = "CLIENT-SUBNET: ### PARSE ERROR ###",
 		.skip_round_trip = true,
 	},
 
@@ -554,7 +554,7 @@ struct test tdata[] = {
 		.input_len = 15,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET:  ### PARSE ERROR #12 ###",
+		.expected = "CLIENT-SUBNET:  ### PARSE ERROR #12 ###",
 		.skip_round_trip = true,
 	},
 
@@ -568,7 +568,7 @@ struct test tdata[] = {
 		.input_len = 15,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; CLIENT-SUBNET:  ### PARSE ERROR #12 ###",
+		.expected = "CLIENT-SUBNET:  ### PARSE ERROR #12 ###",
 		.skip_round_trip = true,
 	},
 
@@ -579,7 +579,7 @@ struct test tdata[] = {
 		.input_len = 5,
 		.rrclass = WDNS_CLASS_IN,
 		.rrtype = WDNS_TYPE_OPT,
-		.expected = "\n; EDE:  ### PARSE ERROR #12 ###",
+		.expected = "EDE:  ### PARSE ERROR #12 ###",
 		.skip_round_trip = true,
 	},
 

--- a/wdns/edns_options.c
+++ b/wdns/edns_options.c
@@ -109,7 +109,6 @@ ip_to_ubuf(ubuf *u, uint16_t addr_family, const uint8_t *src, uint16_t src_bytes
 void
 _wdns_ednsoptcode_to_ubuf(ubuf *u, uint16_t option_code)
 {
-	ubuf_append_cstr_lit(u, "\n; ");
 	switch (option_code) {
 		case edns_client_subnet:
 			ubuf_append_cstr_lit(u, "CLIENT-SUBNET:");

--- a/wdns/message_to_str.c
+++ b/wdns/message_to_str.c
@@ -67,8 +67,20 @@ wdns_message_to_str(wdns_message_t *m)
 		ubuf_add_fmt(u, "\n; EDNS: version: %u, flags:%s; udp: %u", m->edns.version,
 			edns_flags, m->edns.size);
 		if (m->edns.options != NULL) {
-			_wdns_rdata_to_ubuf(u, m->edns.options->data,
+			ubuf *ueopts;
+			char *eopts, *ptr, *opt;
+
+			ueopts = ubuf_new();
+			_wdns_rdata_to_ubuf(ueopts, m->edns.options->data,
 				m->edns.options->len, WDNS_TYPE_OPT, class_un);
+			eopts = ubuf_cstr(ueopts);
+			opt = strtok_r(eopts, "\n", &ptr);
+			while (opt != NULL) {
+				ubuf_append_cstr_lit(u, "\n; ");
+				ubuf_append_cstr(u, opt, strlen(opt));
+				opt = strtok_r(NULL, "\n", &ptr);
+			}
+			ubuf_destroy(&ueopts);
 		}
 	}
 	ubuf_append_cstr_lit(u, "\n;; QUESTION SECTION:\n");

--- a/wdns/rdata_to_ubuf.c
+++ b/wdns/rdata_to_ubuf.c
@@ -723,6 +723,9 @@ _wdns_rdata_to_ubuf(ubuf *u, const uint8_t *rdata, uint16_t rdlen,
 					goto err_res;
 				}
 				bytes_consumed(option_len);
+				if (src_bytes > 0) {
+					ubuf_add(u, '\n');
+				}
 			}
 			break;
 		} /* end case */


### PR DESCRIPTION
This way other users of `_wdns_rdata_to_ubuf()` for edns option data won't have to deal with a leading newline, semicolon, and space.