### PR TITLE
Fix handling of no address for client subnets

### DIFF
--- a/t/test-rdata.c
+++ b/t/test-rdata.c
@@ -583,6 +583,46 @@ struct test tdata[] = {
 		.skip_round_trip = true,
 	},
 
+	{ /* IPv4 Client-Subnet but with 0 source and 0 scope */
+		.input = "\x00\x08"	/* option code */
+		    "\x00\x04"		/* option length */
+		    "\x00\x01"		/* iana addr family */
+		    "\x00"		/* source prefix-length */
+		    "\x00",		/* scope prefix-length */
+		.input_len = 8,
+		.rrclass = WDNS_CLASS_IN,
+		.rrtype = WDNS_TYPE_OPT,
+		.expected = "CLIENT-SUBNET: 0.0.0.0/0/0",
+		.skip_round_trip = true,
+	},
+
+	{ /* IPv6 Client-Subnet but with 0 source and 0 scope */
+		.input = "\x00\x08"	/* option code */
+		    "\x00\x04"		/* option length */
+		    "\x00\x02"		/* iana addr family */
+		    "\x00"		/* source prefix-length */
+		    "\x00",		/* scope prefix-length */
+		.input_len = 8,
+		.rrclass = WDNS_CLASS_IN,
+		.rrtype = WDNS_TYPE_OPT,
+		.expected = "CLIENT-SUBNET: ::/0/0",
+		.skip_round_trip = true,
+	},
+
+	{ /* IPv4 Client-Subnet with truncated address; no final 00 byte */
+		.input = "\x00\x08"	/* option code */
+		    "\x00\x07"		/* option length */
+		    "\x00\x01"		/* iana addr family */
+		    "\x18"		/* source prefix-length */
+		    "\x00"		/* scope prefix-length */
+		    "\xc6\x33\x64",	/* address */
+		.input_len = 11,
+		.rrclass = WDNS_CLASS_IN,
+		.rrtype = WDNS_TYPE_OPT,
+		.expected = "CLIENT-SUBNET: 198.51.100.0/24/0",
+		.skip_round_trip = true,
+	},
+
 	{ 0 }
 };
 

--- a/wdns/edns_options.c
+++ b/wdns/edns_options.c
@@ -87,9 +87,7 @@ ip_to_ubuf(ubuf *u, uint16_t addr_family, const uint8_t *src, uint16_t src_bytes
 	char pres[WDNS_PRESLEN_TYPE_AAAA];
 	uint8_t addr[16] = {0};
 
-	if (src_bytes == 0) {
-		return (wdns_res_parse_error);
-	} else if (addr_family != ip && addr_family != ip6) {
+	if (addr_family != ip && addr_family != ip6) {
 		return (wdns_res_parse_error);
 	} else if (addr_family == ip && src_bytes > 4) {
 		return (wdns_res_parse_error);


### PR DESCRIPTION
Per [RFC 7871](https://datatracker.ietf.org/doc/html/rfc7871#section-6): "ADDRESS is the rest “MUST be truncated to the number of bits indicated by the SOURCE PREFIX-LENGTH field”. 

This change correctly handles if source is `x00` and address is truncated completely. For ipv4 and ipv6 addresses. I also added unit tests to test specifically for this.
