### PR TITLE
Build shared library on cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ wdns/rrtype_to_str.c: wdns/wdns.h wdns/gen_rrtype_to_str
 wdns_libwdns_la_CPPFLAGS = \
 	-include $(top_builddir)/wdns/wdns-private.h
 wdns_libwdns_la_LDFLAGS = $(AM_LDFLAGS) \
+	-no-undefined \
 	-version-info $(LIBWDNS_CURRENT):$(LIBWDNS_REVISION):$(LIBWDNS_AGE)
 if HAVE_LD_VERSION_SCRIPT
 wdns_libwdns_la_LDFLAGS += \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-1.x86_64 2024-02-01 11:02 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/farsightsec/wdns.git
$ cd wdns
$ ./configure --enable-shared --disable-static
$ make V=1
: 
/bin/sh ./libtool  --tag=CC   --mode=link gcc -Wall -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wpointer-arith -Wsign-compare -Wchar-subscripts -Wstrict-prototypes -Wshadow -Wformat-security -I./wdns -g -O2  -version-info 4:1:3 -Wl,--version-script=./wdns/libwdns.sym   -o wdns/libwdns.la -rpath /usr/local/lib libmy/wdns_libwdns_la-b32_decode.lo libmy/wdns_libwdns_la-b32_encode.lo libmy/wdns_libwdns_la-b64_decode.lo libmy/wdns_libwdns_la-b64_encode.lo libmy/wdns_libwdns_la-my_format.lo libmy/wdns_libwdns_la-fast_inet_ntop.lo wdns/libwdns_la-clear.lo wdns/libwdns_la-compare_rr_rrset.lo wdns/libwdns_la-copy_uname.lo wdns/libwdns_la-count_labels.lo wdns/libwdns_la-deserialize_rrset.lo wdns/libwdns_la-domain_to_str.lo wdns/libwdns_la-downcase_name.lo wdns/libwdns_la-downcase_rdata.lo wdns/libwdns_la-downcase_rrset.lo wdns/libwdns_la-edns_options.lo wdns/libwdns_la-file_load_names.lo wdns/libwdns_la-insert_rr_rrset_array.lo wdns/libwdns_la-is_subdomain.lo wdns/libwdns_la-left_chop.lo wdns/libwdns_la-len_uname.lo wdns/libwdns_la-message_to_str.lo wdns/libwdns_la-parse_edns.lo wdns/libwdns_la-parse_header.lo wdns/libwdns_la-parse_message.lo wdns/libwdns_la-parse_message_rr.lo wdns/libwdns_la-parse_rdata.lo wdns/libwdns_la-print_message.lo wdns/libwdns_la-print_rr.lo wdns/libwdns_la-print_rrset.lo wdns/libwdns_la-print_rrset_array.lo wdns/libwdns_la-opcode_to_str.lo wdns/libwdns_la-rcode_to_str.lo wdns/libwdns_la-rdata_to_str.lo wdns/libwdns_la-rdata_to_ubuf.lo wdns/libwdns_la-record_descr.lo wdns/libwdns_la-res_to_str.lo wdns/libwdns_la-reverse_name.lo wdns/libwdns_la-rr_to_str.lo wdns/libwdns_la-rr_to_ubuf.lo wdns/libwdns_la-rrclass_to_str.lo wdns/libwdns_la-rrtype_to_str.lo wdns/libwdns_la-rrset_array_to_str.lo wdns/libwdns_la-rrset_array_to_ubuf.lo wdns/libwdns_la-rrset_to_str.lo wdns/libwdns_la-rrset_to_ubuf.lo wdns/libwdns_la-serialize_rrset.lo wdns/libwdns_la-sort_rrset.lo wdns/libwdns_la-skip_name.lo wdns/libwdns_la-str_to_name.lo wdns/libwdns_la-str_to_rdata_ubuf.lo wdns/libwdns_la-svcparamkeys_to_str.lo wdns/libwdns_la-unpack_name.lo wdns/libwdns_la-version.lo
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!