### PR TITLE
libmy/fast_inet_ntop add/cleanup result codes

### DIFF
--- a/libmy/fast_inet_ntop.c
+++ b/libmy/fast_inet_ntop.c
@@ -64,7 +64,12 @@ static char numstr[100][2] = {
 const char *
 fast_inet4_ntop(const void *restrict src, char *restrict dst, socklen_t size)
 {
-	if (size < INET_ADDRSTRLEN || src == NULL || dst == NULL)
+	if (size < INET_ADDRSTRLEN) {
+		errno = ENOSPC;
+		return NULL;
+	};
+
+	if (src == NULL || dst == NULL)
 		return NULL;
 
 	char *sptr = dst;
@@ -116,7 +121,12 @@ fast_inet6_ntop(const void *restrict src, char *restrict dst, socklen_t size)
 	int i;
 	const uint8_t *psrc = (const uint8_t *) src;
 
-	if (size < INET6_ADDRSTRLEN || src == NULL || dst == NULL)
+	if (size < INET6_ADDRSTRLEN) {
+		errno = ENOSPC;
+		return NULL;
+	};
+
+	if (src == NULL || dst == NULL)
 		return NULL;
 
 	/*

--- a/t/test-fast_inet_ntop.c
+++ b/t/test-fast_inet_ntop.c
@@ -84,10 +84,8 @@ test_fast_inet_ntop(void) {
 
 	/* error result tests */
 
-	inet_pton(AF_INET, "0.0.0.0", abuf);
-
 	errno = 0;
-	result = fast_inet_ntop(2147483647, abuf, buf, sizeof(buf));
+	result = fast_inet_ntop(0, "0", buf, sizeof(buf));
 	if (result == NULL && errno == EAFNOSUPPORT) {
 		fprintf(stderr, "PASS: fast_inet_ntop unknown address family results in EAFNOSUPPORT\n");
 	} else {
@@ -96,11 +94,20 @@ test_fast_inet_ntop(void) {
 	}
 
 	errno = 0;
-	result = fast_inet_ntop(AF_APPLETALK, abuf, buf, sizeof(buf));
-	if (result == NULL && errno == EAFNOSUPPORT) {
-		fprintf(stderr, "PASS: fast_inet_ntop unsupported address family results in EAFNOSUPPORT\n");
+	result = fast_inet_ntop(AF_INET, "0", buf, 1);
+	if (result == NULL && errno == ENOSPC) {
+		fprintf(stderr, "PASS: fast_inet_ntop too small destination space for IPv4 presentation results in ENOSPC\n");
 	} else {
-		fprintf(stderr, "FAIL: fast_inet_ntop unsupported address family results in EAFNOSUPPORT\n");
+		fprintf(stderr, "FAIL: fast_inet_ntop too small destination space for IPv4 presentation results in ENOSPC\n");
+		failures++;
+	}
+
+	errno = 0;
+	result = fast_inet_ntop(AF_INET6, "0", buf, 5);
+	if (result == NULL && errno == ENOSPC) {
+		fprintf(stderr, "PASS: fast_inet_ntop too small destination space for IPv6 presentation results in ENOSPC\n");
+	} else {
+		fprintf(stderr, "FAIL: fast_inet_ntop too small destination space for IPv6 presentation results in ENOSPC\n");
 		failures++;
 	}
 


### PR DESCRIPTION
and add tests:

PASS: fast_inet_ntop unknown address family results in EAFNOSUPPORT
PASS: fast_inet_ntop too small destination space for IPv4 presentation results in ENOSPC
PASS: fast_inet_ntop too small destination space for IPv6 presentation results in ENOSPC