### PR TITLE
Fix off-by-one out-of-bounds read in wdns_unpack_name()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,3 +255,8 @@ t_test_str_to_rrtype_LDADD = wdns/libwdns.la
 TESTS += t/test-fast_inet_ntop
 check_PROGRAMS += t/test-fast_inet_ntop
 t_test_fast_inet_ntop_SOURCES = t/test-fast_inet_ntop.c t/test-common.c
+
+TESTS += t/test-unpack_name
+check_PROGRAMS += t/test-unpack_name
+t_test_unpack_name_SOURCES = t/test-unpack_name.c t/test-common.c
+t_test_unpack_name_LDADD = wdns/libwdns.la

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "test-common.h"
+
+#include <libmy/ubuf.h>
+#include <wdns.h>
+
+#define NAME "test-unpack_name"
+
+/*
+ * A single-octet message consisting solely of a compression pointer's first
+ * byte (0xC0). The second octet of the pointer would lie at eop, i.e. one
+ * byte past the end of the message. This is a regression test for a bug
+ * where wdns_unpack_name() read that missing second octet anyway instead of
+ * detecting the truncation.
+ */
+static const uint8_t msg_truncated_pointer[] = { 0xC0 };
+
+/* A compression pointer to the root label at offset 0. */
+static const uint8_t msg_valid_pointer[] = { 0x00, 0xC0, 0x00 };
+
+/* An uncompressed name: www.example.com */
+static const uint8_t msg_uncompressed[] = {
+	3, 'w', 'w', 'w',
+	7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+	3, 'c', 'o', 'm',
+	0
+};
+
+struct test {
+	const char *descr;
+	const uint8_t *msg;
+	size_t msglen;
+	size_t name_offset;
+	wdns_res expected_res;
+	const uint8_t *expected_name;
+	size_t expected_len;
+};
+
+static struct test tdata[] = {
+	{
+		"compression pointer truncated at end of message",
+		msg_truncated_pointer, sizeof(msg_truncated_pointer), 0,
+		wdns_res_out_of_bounds, NULL, 0
+	},
+	{
+		"compression pointer to root label",
+		msg_valid_pointer, sizeof(msg_valid_pointer), 1,
+		wdns_res_success, msg_valid_pointer, 1
+	},
+	{
+		"uncompressed name",
+		msg_uncompressed, sizeof(msg_uncompressed), 0,
+		wdns_res_success, msg_uncompressed, sizeof(msg_uncompressed)
+	},
+	{ NULL, NULL, 0, 0, wdns_res_success, NULL, 0 }
+};
+
+static size_t
+test_unpack_name(void)
+{
+	ubuf *u;
+	struct test *cur;
+	size_t failures = 0;
+
+	u = ubuf_init(256);
+
+	for (cur = tdata; cur->descr != NULL; cur++) {
+		uint8_t dst[WDNS_MAXLEN_NAME];
+		size_t len = 0;
+		wdns_res res;
+
+		ubuf_reset(u);
+
+		res = wdns_unpack_name(cur->msg, cur->msg + cur->msglen,
+					cur->msg + cur->name_offset, dst, &len);
+
+		if (res != cur->expected_res) {
+			ubuf_add_fmt(u, "FAIL %s: res=%s != %s",
+				     cur->descr,
+				     wdns_res_to_str(res),
+				     wdns_res_to_str(cur->expected_res));
+			failures++;
+		} else if (res == wdns_res_success &&
+			   (len != cur->expected_len ||
+			    memcmp(dst, cur->expected_name, len) != 0))
+		{
+			ubuf_add_fmt(u, "FAIL %s: len=%" PRIu64 " != %" PRIu64 " or value mismatch",
+				     cur->descr, (uint64_t)len, (uint64_t)cur->expected_len);
+			failures++;
+		} else {
+			ubuf_add_fmt(u, "PASS %s: res=%s",
+				     cur->descr, wdns_res_to_str(res));
+		}
+
+		fprintf(stderr, "%s\n", ubuf_cstr(u));
+	}
+
+	ubuf_destroy(&u);
+	return failures;
+}
+
+int main(void)
+{
+	int ret = 0;
+
+	ret |= check(test_unpack_name(), "test_unpack_name", NAME);
+
+	if (ret)
+		return (EXIT_FAILURE);
+	return (EXIT_SUCCESS);
+}

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -39,6 +39,9 @@ static const uint8_t msg_truncated_pointer[] = { 0xC0 };
 /* A compression pointer to the root label at offset 0. */
 static const uint8_t msg_valid_pointer[] = { 0x00, 0xC0, 0x00 };
 
+/* A compression pointer whose target is exactly one past the message. */
+static const uint8_t msg_pointer_to_end[] = { 0x00, 0xC0, 0x03 };
+
 /* An uncompressed name: www.example.com */
 static const uint8_t msg_uncompressed[] = {
 	3, 'w', 'w', 'w',
@@ -67,6 +70,11 @@ static struct test tdata[] = {
 		"compression pointer to root label",
 		msg_valid_pointer, sizeof(msg_valid_pointer), 1,
 		wdns_res_success, msg_valid_pointer, 1
+	},
+	{
+		"compression pointer target at end of message",
+		msg_pointer_to_end, sizeof(msg_pointer_to_end), 1,
+		wdns_res_invalid_compression_pointer, NULL, 0
 	},
 	{
 		"uncompressed name",

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -45,7 +45,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 		if (c >= 192) {
 			uint16_t offset;
 
-			if (src > eop)
+			if (src >= eop)
 				return (wdns_res_out_of_bounds);
 
 			/* offset is the lower 14 bits of the 2 octet sequence */

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -53,7 +53,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 
 			cptr = p + offset;
 
-			if (cptr > eop)
+			if (cptr >= eop)
 				return (wdns_res_invalid_compression_pointer);
 			if (cptr > src - 2) {
 				return (wdns_res_invalid_compression_pointer);


### PR DESCRIPTION
## Bug

When unpacking a compressed DNS name, the check on the compression
pointer's second octet is off by one:

```c
if (src > eop)
    return (wdns_res_out_of_bounds);

/* offset is the lower 14 bits of the 2 octet sequence */
offset = ((c & 63) << 8) + *src;
```

`eop` is used consistently throughout the library as an exclusive
"one past the last valid byte" pointer (see the entry guard on the
same function, `if (p >= eop || src >= eop || src < p) ...`, and
`pkt_end = pkt + len` in `parse_message.c`). After the marker byte is
consumed, `src` points at the position of the pointer's second octet,
so for `*src` to be a valid read, `src` must be `< eop`. The existing
check only rejects `src > eop`, letting `src == eop` through, and the
next line then dereferences `*src`, reading one byte past the end of
the message buffer.

This is reachable from the public `wdns_parse_message()` entry point
whenever a DNS message's last byte is a compression-pointer marker
octet (`0xC0`-`0xFF`) with nothing after it, i.e. from
fully attacker/network-controlled input.

## Verification

I built a 1-byte buffer containing `0xC0` placed immediately before a
`PAGE_NOACCESS` guard page and called the real compiled
`wdns_unpack_name()` against it. The unpatched code reliably raises a
hardware access violation reading exactly at `eop` (one byte past the
buffer); with this one-character fix it instead returns
`wdns_res_out_of_bounds` cleanly.

## Fix

Changes the check to `src >= eop`, matching the exclusive-end-pointer
convention used everywhere else in this function.

## Tests

Adds `t/test-unpack_name.c` (there was no existing test file for this
function), with three cases:
- the truncated-pointer case above, expecting `wdns_res_out_of_bounds`
- a valid compression pointer to the root label, to confirm the
  tightened check doesn't reject legitimate compressed names
- a plain uncompressed name, as a basic sanity check

I compiled this test file against the unmodified `unpack_name.c` and
confirmed it fails (returns `wdns_res_invalid_compression_pointer`
instead of `wdns_res_out_of_bounds` -- the OOB read doesn't always
crash on every memory layout, but it does return the wrong result),
and confirmed it passes cleanly against the patched version.