### PR TITLE
Fix eop comparison in wdns_unpack_name

### DIFF
--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -45,7 +45,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 		if (c >= 192) {
 			uint16_t offset;
 
-			if (src > eop)
+			if (src >= eop)
 				return (wdns_res_out_of_bounds);
 
 			/* offset is the lower 14 bits of the 2 octet sequence */
@@ -53,8 +53,6 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 
 			cptr = p + offset;
 
-			if (cptr > eop)
-				return (wdns_res_invalid_compression_pointer);
 			if (cptr > src - 2) {
 				return (wdns_res_invalid_compression_pointer);
 			} else {


### PR DESCRIPTION
Prompted by PR #75, this also removes a redundant  off-by-one eop check of the compression pointer.
