### PR TITLE
Bounds check fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -255,3 +255,8 @@ t_test_str_to_rrtype_LDADD = wdns/libwdns.la
 TESTS += t/test-fast_inet_ntop
 check_PROGRAMS += t/test-fast_inet_ntop
 t_test_fast_inet_ntop_SOURCES = t/test-fast_inet_ntop.c t/test-common.c
+
+TESTS += t/test-unpack_name
+check_PROGRAMS += t/test-unpack_name
+t_test_unpack_name_SOURCES = t/test-unpack_name.c t/test-common.c
+t_test_unpack_name_LDADD = wdns/libwdns.la

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "test-common.h"
+
+#include <libmy/ubuf.h>
+#include <wdns.h>
+
+#define NAME "test-unpack_name"
+
+/*
+ * A single-octet message consisting solely of a compression pointer's first
+ * byte (0xC0). The second octet of the pointer would lie at eop, i.e. one
+ * byte past the end of the message. This is a regression test for a bug
+ * where wdns_unpack_name() read that missing second octet anyway instead of
+ * detecting the truncation.
+ */
+static const uint8_t msg_truncated_pointer[] = { 0xC0 };
+
+/* A compression pointer to the root label at offset 0. */
+static const uint8_t msg_valid_pointer[] = { 0x00, 0xC0, 0x00 };
+
+/* An uncompressed name: www.example.com */
+static const uint8_t msg_uncompressed[] = {
+	3, 'w', 'w', 'w',
+	7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+	3, 'c', 'o', 'm',
+	0
+};
+
+struct test {
+	const char *descr;
+	const uint8_t *msg;
+	size_t msglen;
+	size_t name_offset;
+	wdns_res expected_res;
+	const uint8_t *expected_name;
+	size_t expected_len;
+};
+
+static struct test tdata[] = {
+	{
+		"compression pointer truncated at end of message",
+		msg_truncated_pointer, sizeof(msg_truncated_pointer), 0,
+		wdns_res_out_of_bounds, NULL, 0
+	},
+	{
+		"compression pointer to root label",
+		msg_valid_pointer, sizeof(msg_valid_pointer), 1,
+		wdns_res_success, msg_valid_pointer, 1
+	},
+	{
+		"uncompressed name",
+		msg_uncompressed, sizeof(msg_uncompressed), 0,
+		wdns_res_success, msg_uncompressed, sizeof(msg_uncompressed)
+	},
+	{ NULL, NULL, 0, 0, wdns_res_success, NULL, 0 }
+};
+
+static size_t
+test_unpack_name(void)
+{
+	ubuf *u;
+	struct test *cur;
+	size_t failures = 0;
+
+	u = ubuf_init(256);
+
+	for (cur = tdata; cur->descr != NULL; cur++) {
+		uint8_t dst[WDNS_MAXLEN_NAME];
+		size_t len = 0;
+		wdns_res res;
+
+		ubuf_reset(u);
+
+		res = wdns_unpack_name(cur->msg, cur->msg + cur->msglen,
+					cur->msg + cur->name_offset, dst, &len);
+
+		if (res != cur->expected_res) {
+			ubuf_add_fmt(u, "FAIL %s: res=%s != %s",
+				     cur->descr,
+				     wdns_res_to_str(res),
+				     wdns_res_to_str(cur->expected_res));
+			failures++;
+		} else if (res == wdns_res_success &&
+			   (len != cur->expected_len ||
+			    memcmp(dst, cur->expected_name, len) != 0))
+		{
+			ubuf_add_fmt(u, "FAIL %s: len=%" PRIu64 " != %" PRIu64 " or value mismatch",
+				     cur->descr, (uint64_t)len, (uint64_t)cur->expected_len);
+			failures++;
+		} else {
+			ubuf_add_fmt(u, "PASS %s: res=%s",
+				     cur->descr, wdns_res_to_str(res));
+		}
+
+		fprintf(stderr, "%s\n", ubuf_cstr(u));
+	}
+
+	ubuf_destroy(&u);
+	return failures;
+}
+
+int main(void)
+{
+	int ret = 0;
+
+	ret |= check(test_unpack_name(), "test_unpack_name", NAME);
+
+	if (ret)
+		return (EXIT_FAILURE);
+	return (EXIT_SUCCESS);
+}

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -39,6 +39,9 @@ static const uint8_t msg_truncated_pointer[] = { 0xC0 };
 /* A compression pointer to the root label at offset 0. */
 static const uint8_t msg_valid_pointer[] = { 0x00, 0xC0, 0x00 };
 
+/* A compression pointer whose target is exactly one past the message. */
+static const uint8_t msg_pointer_to_end[] = { 0x00, 0xC0, 0x03 };
+
 /* An uncompressed name: www.example.com */
 static const uint8_t msg_uncompressed[] = {
 	3, 'w', 'w', 'w',
@@ -67,6 +70,11 @@ static struct test tdata[] = {
 		"compression pointer to root label",
 		msg_valid_pointer, sizeof(msg_valid_pointer), 1,
 		wdns_res_success, msg_valid_pointer, 1
+	},
+	{
+		"compression pointer target at end of message",
+		msg_pointer_to_end, sizeof(msg_pointer_to_end), 1,
+		wdns_res_invalid_compression_pointer, NULL, 0
 	},
 	{
 		"uncompressed name",

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -81,6 +81,11 @@ static struct test tdata[] = {
 		msg_uncompressed, sizeof(msg_uncompressed), 0,
 		wdns_res_success, msg_uncompressed, sizeof(msg_uncompressed)
 	},
+	{
+		"uncompressed name with terminating label after eop",
+		msg_uncompressed, sizeof(msg_uncompressed)-1, 0,
+		wdns_res_out_of_bounds, NULL, 0
+	},
 	{ NULL, NULL, 0, 0, wdns_res_success, NULL, 0 }
 };
 

--- a/t/test-unpack_name.c
+++ b/t/test-unpack_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 by Farsight Security, Inc.
+ * Copyright (c) 2026 DomainTools LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/wdns/copy_uname.c
+++ b/wdns/copy_uname.c
@@ -50,7 +50,7 @@ wdns_copy_uname(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 			total_len += c;
 			if (total_len >= WDNS_MAXLEN_NAME)
 				return (wdns_res_name_overflow);
-			if (src + c > eop)
+			if (src + c >= eop)
 				return (wdns_res_out_of_bounds);
 			memcpy(dst, src, c);
 

--- a/wdns/skip_name.c
+++ b/wdns/skip_name.c
@@ -33,7 +33,7 @@ wdns_skip_name(const uint8_t **data, const uint8_t *eod)
 	size_t bytes_skipped;
 	uint8_t c;
 
-	while (src <= eod && (c = *src) != 0) {
+	while (src < eod && (c = *src) != 0) {
 		if (c >= 192) {
 			/* compression pointers occupy two octets */
 			src++;

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -67,7 +67,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 			total_len += c;
 			if (total_len >= WDNS_MAXLEN_NAME)
 				return (wdns_res_name_overflow);
-			if (src + c > eop)
+			if (src + c >= eop)
 				return (wdns_res_out_of_bounds);
 			memcpy(dst, src, c);
 

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -45,7 +45,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 		if (c >= 192) {
 			uint16_t offset;
 
-			if (src > eop)
+			if (src >= eop)
 				return (wdns_res_out_of_bounds);
 
 			/* offset is the lower 14 bits of the 2 octet sequence */

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -53,8 +53,6 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 
 			cptr = p + offset;
 
-			if (cptr >= eop)
-				return (wdns_res_invalid_compression_pointer);
 			if (cptr > src - 2) {
 				return (wdns_res_invalid_compression_pointer);
 			} else {

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -53,7 +53,7 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 
 			cptr = p + offset;
 
-			if (cptr > eop)
+			if (cptr >= eop)
 				return (wdns_res_invalid_compression_pointer);
 			if (cptr > src - 2) {
 				return (wdns_res_invalid_compression_pointer);

--- a/wdns/unpack_name.c
+++ b/wdns/unpack_name.c
@@ -53,6 +53,21 @@ wdns_unpack_name(const uint8_t *p, const uint8_t *eop, const uint8_t *src,
 
 			cptr = p + offset;
 
+			/*
+			 * We require the compression pointer to point to an earlier
+			 * octet in the message, per RFC 1035's description of a compression
+			 * pointer pointing to a "prior occurrence" of a name.
+			 *
+			 * This requirement prevents compression pointer cycles, and cycles
+			 * between a (nonzero) label length and compression pointer will
+			 * terminate due to limited name length (WDNS_MAXLEN_NAME).
+			 *
+			 * This requirement could be stricter, as a well-formed compression
+			 * pointer should point to a name beginning and ending before the
+			 * sequence of labels ending in the pointer. However, such a restriction
+			 * is stricter than most extant DNS software and would result in wdns
+			 * rejecting DNS messages most other DNS software would accept.
+			 */
 			if (cptr > src - 2) {
 				return (wdns_res_invalid_compression_pointer);
 			} else {


### PR DESCRIPTION
Fix multiple off-by-one errors in bounds checking in `wdns_unpack_name`, `wdns_skip_name`, and `wdns_copy_uname`.