### PR TITLE
Fix base64 decoding on platforms where char is unsigned

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -252,3 +252,7 @@ t_test_str_to_rrtype_LDADD = wdns/libwdns.la
 TESTS += t/test-fast_inet_ntop
 check_PROGRAMS += t/test-fast_inet_ntop
 t_test_fast_inet_ntop_SOURCES = t/test-fast_inet_ntop.c t/test-common.c
+
+TESTS += t/test-b64_decode
+check_PROGRAMS += t/test-b64_decode
+t_test_b64_decode_SOURCES = t/test-b64_decode.c t/test-common.c

--- a/libmy/b64_decode.c
+++ b/libmy/b64_decode.c
@@ -9,11 +9,11 @@ For details, see http://sourceforge.net/projects/libb64
 
 int base64_decode_value(char value_in)
 {
-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
-	static const char decoding_size = sizeof(decoding);
-	value_in -= 43;
-	if (value_in < 0 || value_in > decoding_size) return -1;
-	return decoding[(int)value_in];
+	static const signed char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const int decoding_size = sizeof(decoding);
+	int offset = (int) (unsigned char) value_in - 43;
+	if (offset < 0 || offset >= decoding_size) return -1;
+	return decoding[offset];
 }
 
 void base64_init_decodestate(base64_decodestate* state_in)
@@ -26,7 +26,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	char fragment;
+	int fragment;
 
 	*plainchar = state_in->plainchar;
 
@@ -42,7 +42,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
 	case step_b:
@@ -53,7 +53,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
@@ -65,7 +65,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
@@ -77,7 +77,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++   |= (fragment & 0x03f);
 		}

--- a/t/test-b64_decode.c
+++ b/t/test-b64_decode.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-common.h"
+
+#include "libmy/b64_decode.h"
+#include "libmy/b64_decode.c"
+
+#include <string.h>
+
+#define NAME "test-b64_decode"
+
+/*
+ * base64_decode_value() must report every non-alphabet octet as negative,
+ * whatever the sign of a plain char is on this platform.  base64_decode_block()
+ * relies on that to skip padding and whitespace.
+ */
+static size_t
+test_decode_value(void) {
+	size_t failures = 0;
+	size_t i;
+	static const struct {
+		char input;
+		int expected;
+	} testdata[] = {
+		{ 'A', 0 },
+		{ 'Z', 25 },
+		{ 'a', 26 },
+		{ 'z', 51 },
+		{ '0', 52 },
+		{ '9', 61 },
+		{ '+', 62 },
+		{ '/', 63 },
+		{ '=', -2 },
+		{ ' ', -1 },
+		{ '\t', -1 },
+		{ '\n', -1 },
+		{ '\r', -1 },
+		{ '-', -1 },
+		{ '{', -1 },	/* one past the end of the decoding table */
+		{ '\x7f', -1 },
+		{ '\xff', -1 },
+	};
+
+	for (i = 0; i < sizeof(testdata)/sizeof(testdata[0]); i++) {
+		int res = base64_decode_value(testdata[i].input);
+
+		if (res == testdata[i].expected) {
+			fprintf(stderr, "PASS %zu: base64_decode_value(0x%02x) = %d\n",
+				i, (unsigned char) testdata[i].input, res);
+		} else {
+			fprintf(stderr, "FAIL %zu: base64_decode_value(0x%02x) = %d != %d\n",
+				i, (unsigned char) testdata[i].input, res,
+				testdata[i].expected);
+			failures++;
+		}
+	}
+
+	return (failures);
+}
+
+/*
+ * Decoding must ignore padding and embedded whitespace.  DNSKEY, CDNSKEY,
+ * RRSIG and OPENPGPKEY presentation format all carry both.
+ */
+static size_t
+test_decode_block(void) {
+	size_t failures = 0;
+	size_t i;
+	static const struct {
+		const char *input;
+		const char *expected;
+		size_t elen;
+	} testdata[] = {
+		{ "AQIDBAUGBwg=", "\x01\x02\x03\x04\x05\x06\x07\x08", 8 },
+		{ "ZGVhZGJlZWY=", "deadbeef", 8 },
+		{ "ZGVhZGJlZWY==", "deadbeef", 8 },
+		{ "ZGVh ZGJl ZWY=", "deadbeef", 8 },
+		{ "ZGVhZGJl\nZWY=", "deadbeef", 8 },
+		{ "ZGVhZGJl\r\n\tZWY=", "deadbeef", 8 },
+		{ "  ZGVhZGJlZWY=  ", "deadbeef", 8 },
+		{ "AA==", "\x00", 1 },
+		{ "", "", 0 },
+	};
+
+	for (i = 0; i < sizeof(testdata)/sizeof(testdata[0]); i++) {
+		base64_decodestate b64;
+		char buf[64];
+		int len;
+
+		memset(buf, 0, sizeof(buf));
+		base64_init_decodestate(&b64);
+		len = base64_decode_block(testdata[i].input,
+					  strlen(testdata[i].input),
+					  buf, &b64);
+
+		if (len == (int) testdata[i].elen &&
+		    memcmp(buf, testdata[i].expected, testdata[i].elen) == 0)
+		{
+			fprintf(stderr, "PASS %zu: base64_decode_block(\"%s\") len %d\n",
+				i, testdata[i].input, len);
+		} else {
+			ubuf *u = ubuf_init(64);
+
+			escape(u, (const uint8_t *) buf, len < 0 ? 0 : (size_t) len);
+			fprintf(stderr, "FAIL %zu: base64_decode_block(\"%s\") len %d != %zu value=%s\n",
+				i, testdata[i].input, len, testdata[i].elen,
+				ubuf_cstr(u));
+			ubuf_destroy(&u);
+			failures++;
+		}
+	}
+
+	return (failures);
+}
+
+int main (void) {
+	int ret = 0;
+
+	ret |= check(test_decode_value(), "test_decode_value", NAME);
+	ret |= check(test_decode_block(), "test_decode_block", NAME);
+
+	if (ret)
+		return (EXIT_FAILURE);
+
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
This PR proposes fixing base64 decoding on platforms where `char` is unsigned, which corrupts DNSKEY, CDNSKEY, RRSIG and OPENPGPKEY rdata on AArch64 (fixes #70). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/387. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`base64_decode_value()` in `libmy/b64_decode.c` keeps its decoding table in a plain `char` array and signals "not a base64 alphabet octet" by returning a negative sentinel (`-1`, and `-2` for `=`). On AArch64, ppc64le and s390x, where `char` is unsigned by default, those sentinels come back as `255` and `254`. The four `while (fragment < 0)` loops in `base64_decode_block()` therefore never skip anything: padding and the whitespace that separates presentation-format key chunks are folded into the output as if they were real base64 digits. `wdns_str_to_rdata()` (`wdns/str_to_rdata_ubuf.c:93`) is the direct caller, so every base64-encoded rdata type comes back longer and silently wrong — the `len 140 != 134` and trailing `>` byte in the report.

While confirming that, I also found a one-past-the-end read in the same bounds check: `value_in > decoding_size` admits `value_in == 80` on an 80-element table. The character `{` hits it, and on this machine it read back `65`, so `{` decodes as a valid base64 value instead of being rejected. That one is not platform-dependent.

## The change

`decoding[]` becomes `signed char`, the table offset is computed in an `int` from `(unsigned char) value_in`, `fragment` becomes an `int`, and the bounds check uses `>=`. Behavior on signed-`char` platforms is unchanged: for octets `>= 0x80` the old code went negative before the comparison and returned `-1`, and the new code produces an offset `>= 80` and returns `-1` as well.

## Reproduction at current HEAD

AArch64's ABI is `unsigned char`, so `-funsigned-char` reproduces it on any host. On `master` (c308fe8):

```
$ ./autogen.sh && ./configure CFLAGS="-g -O2 -funsigned-char" && make && make check
FAIL: t/test-str_to_rdata
FAIL: t/test-rdata
# TOTAL: 7
# PASS:  5
# FAIL:  2
```

That is the same 5-pass/2-fail split as the report, with the same failing cases:

```
FAIL 1: input="256 3 5 AQPSKmynfzW4kyBv015MUG2DeIQ3 Cbl+BBZH4b/0PY1kxkmvHjcZc8no ..." IN DNSKEY len 140 != 134
FAIL 5: input="AQIDBAUGBwg=" IN OPENPGPKEY len 9 != 8 res=success value="\x01\x02\x03\x04\x05\x06\x07\x08>" != "\x01\x02\x03\x04\x05\x06\x07\x08"
```

## Verification

A new `t/test-b64_decode` covers the sentinels, `=` padding and embedded whitespace, following the pattern `t/test-fast_inet_ntop` uses for `libmy` code. It is red on the unpatched tree in **both** configurations — 11 failures under `-funsigned-char`, and 1 failure in a default build from the `{` out-of-bounds read:

```
FAIL 8: base64_decode_value(0x3d) = 254 != -2
FAIL 14: base64_decode_value(0x7b) = 65 != -1
FAIL 3: base64_decode_block("ZGVh ZGJl ZWY=") len 10 != 8 value="dea\xfd\x91\x89\x97\xf6Vc"
```

With the patch applied, both configurations are fully green and nothing that passed before regressed:

```
default CFLAGS   : # TOTAL: 8  # PASS: 8  # FAIL: 0   (baseline before the patch: 7/7)
-funsigned-char  : # TOTAL: 8  # PASS: 8  # FAIL: 0   (baseline before the patch: 5/7)
```

The real consumer path is covered by your own suite: `t/test-str_to_rdata` and `t/test-rdata` round-trip DNSKEY, CDNSKEY, RRSIG and OPENPGPKEY through `wdns_str_to_rdata()`, and both go from failing to passing under `-funsigned-char`.

No public signature, dependency or build setting changed. I left `ChangeLog` alone to avoid colliding with #78.

## How this was managed

We imported your issues and pull requests into a live agile board — 78 stories and 1 label — and worked this change on the story for issue #70: https://eastagiletracker.com/projects/387/stories/260343. The board itself is at https://eastagiletracker.com/projects/387.

![board](https://raw.githubusercontent.com/eastagiletracker/wdns/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
